### PR TITLE
version 1.0.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,9 @@
 Version 1.0.1
 - add validation/check of handlebars expression syntax.
+- add line no and char no in error message 
 - enforce to use Handlebars 2.0.0 for parsing.
+- using chai to replace expect.js 
+- enhance the unit test with comments (refactor)
 
 Version 1.0.0
 - init release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Version 1.0.1
+- add validation/check of handlebars expression syntax.
+- enforce to use Handlebars 2.0.0 for parsing.
+
+Version 1.0.0
+- init release.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "bluebird": "*",
+    "chai": "^2.*",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
     "grunt-cli": "0.1.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-parser-handlebars",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "licenses": [
     {
       "type": "BSD",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "bluebird": "*",
     "chai": "^2.*",
-    "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
     "grunt-cli": "0.1.*",
     "grunt-contrib-clean": "^0.6.0",

--- a/src/handlebars-utils.js
+++ b/src/handlebars-utils.js
@@ -19,7 +19,7 @@ var debugBranch = require('debug')('cph-branching');
 */
 var HandlebarsUtils = {};
 
-/* vanillia Handlebars */
+/* vanilla Handlebars */
 var Handlebars = require("handlebars");
 
 /**
@@ -46,18 +46,21 @@ HandlebarsUtils.generateNonce = function() {
 };
 
 /* type of expression */
-HandlebarsUtils.NOT_EXPRESSION 		= 0;
-HandlebarsUtils.ESCAPE_EXPRESSION 	= 1;
-HandlebarsUtils.RAW_EXPRESSION 		= 2;
+HandlebarsUtils.NOT_EXPRESSION = 0;
+HandlebarsUtils.ESCAPE_EXPRESSION = 1;
+HandlebarsUtils.RAW_EXPRESSION = 2;
 
 /* RegExp to match expression */
-HandlebarsUtils.escapeExpressionRegExp 	  = /^\{\{[^\}\{]+?\}\}(?!})/;
-HandlebarsUtils.rawExpressionRegExp 	  = /^\{\{\{[^\}\{]+?\}\}\}(?!})/;
+/* '{{' 'non-{,non-}'+ '}}' and not follow by '}' */
+HandlebarsUtils.escapeExpressionRegExp = /^\{\{[^\}\{]+?\}\}(?!})/;
+/* '{{{' 'non-{,non-}'+ '}}}' and not follow by '}' */
+HandlebarsUtils.rawExpressionRegExp = /^\{\{\{[^\}\{]+?\}\}\}(?!})/;
 /* '{{' '# or ^' 'space'* 'non-space,non-},non-{'+ first-'space or }' */
-HandlebarsUtils.branchExpressionRegExp 	  = /^\{\{[#|\\^]\s*([^\s\}\{]+)?[\s\}]/;
+HandlebarsUtils.branchExpressionRegExp = /^\{\{[#|\\^]\s*([^\s\}\{]+)?[\s\}]/;
 /* '{{' '/' 'space'* 'non-space,non-},non-{'+ first-'space or }' */
 HandlebarsUtils.branchEndExpressionRegExp = /^\{\{\/\s*([^\s\}\{]+)?[\s\}]/;
-HandlebarsUtils.elseExpressionRegExp      = /^\{\{\s*else\s*?\}\}/;
+/* '{{' 'space'* 'else' 'space'* '}}' */
+HandlebarsUtils.elseExpressionRegExp = /^\{\{\s*else\s*?\}\}/;
 
 /**
 * @function HandlebarsUtils.isValidExpression

--- a/tests/samples/files/handlebarsjs_filter_015.hbs
+++ b/tests/samples/files/handlebarsjs_filter_015.hbs
@@ -1,3 +1,3 @@
 <script>var a = '{{value1}}';</script>
-<script>var a =		'{{value2}}';</script>
+<script>var a =		"{{value2}}";</script>
 <script>var a =	{{value3}};</script>

--- a/tests/samples/files/handlebarsjs_template_021.hbs
+++ b/tests/samples/files/handlebarsjs_template_021.hbs
@@ -1,0 +1,4 @@
+<html>
+{{ expression1 }}
+{{ expression2 }
+</html>

--- a/tests/samples/files/handlebarsjs_template_022.hbs
+++ b/tests/samples/files/handlebarsjs_template_022.hbs
@@ -1,0 +1,4 @@
+<html>
+{{{ expression1 }}}
+{{{ expression2 }}
+</html>

--- a/tests/unit/000-run-precompiler-spec.js
+++ b/tests/unit/000-run-precompiler-spec.js
@@ -9,10 +9,10 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 */
 (function () {
 
-    var mocha = require("mocha"),
-        promise = require('bluebird'),
+    require("mocha");
+    var promise = require('bluebird'),
         fs = require('fs'),
-        expect = require('expect.js'),
+        expect = require('chai').expect,
         ContextParserHandlebars = require("../../src/context-parser-handlebars");
 
     var NO_OF_TEMPLATE = 22,

--- a/tests/unit/000-run-precompiler-spec.js
+++ b/tests/unit/000-run-precompiler-spec.js
@@ -15,7 +15,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         expect = require('expect.js'),
         ContextParserHandlebars = require("../../src/context-parser-handlebars");
 
-    var NO_OF_TEMPLATE = 20,
+    var NO_OF_TEMPLATE = 22,
         NO_OF_FILTER_TEMPLATE = 20;
 
     describe("Handlebars pre-compiler test suite", function() {
@@ -107,9 +107,30 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             var exec = promise.promisify(require("child_process").exec);
             exec('./bin/handlebarspc ./tests/samples/files/handlebarsjs_template_019.hbs')
             .timeout(300)
-            .then(function(streams){
+            .then(function(e){
                 done();
             });
         });
+
+        /* this test will throw exception, and the vanilla handlebars will complain */
+        it("./bin/handlebarspc conditional/iteration mismatch template test", function(done) {
+            var exec = promise.promisify(require("child_process").exec);
+            exec('./bin/handlebarspc ./tests/samples/files/handlebarsjs_template_021.hbs')
+            .timeout(300)
+            .catch(function(e){
+                done();
+            });
+        });
+
+        /* this test will throw exception, and the vanilla handlebars will complain */
+        it("./bin/handlebarspc conditional/iteration mismatch template test", function(done) {
+            var exec = promise.promisify(require("child_process").exec);
+            exec('./bin/handlebarspc ./tests/samples/files/handlebarsjs_template_022.hbs')
+            .timeout(300)
+            .catch(function(e){
+                done();
+            });
+        });
+
     });
 }());

--- a/tests/unit/run-filters.spec.js
+++ b/tests/unit/run-filters.spec.js
@@ -9,9 +9,10 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 */
 (function () {
 
-    var mocha = require("mocha"),
-        fs = require('fs'),
-        expect = require('expect.js'),
+    require("mocha");
+    var fs = require('fs'),
+        expect = require('chai').expect,
+        utils = require('../utils.js'),
         ContextParserHandlebars = require("../../src/context-parser-handlebars");
 
     /* 
@@ -22,492 +23,389 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         it("Filter 000 - add yd filters test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_000.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd name}}}/);
+            var arr = [ 
+                /{{{yd name}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 001 - add yd and yc filters test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_001.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yc comment}}}/);
-            expect(data).to.match(/{{{yd name}}}/);
+            var arr = [ 
+                /{{{yc comment}}}/, /{{{yd name}}}/ 
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 002 - add href filters test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_002.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url11\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url12\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url13\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url14\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url15\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url16\)\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q11\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q14\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q15\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q17\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q18\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q19\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q20\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q21\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q22\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q23\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q24\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q25\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash16\)}}}/);
+            var arr = [ 
+                // test against double quoted, single quoted and unquoted URL in attribute href
+                /{{{yubl \(yavd \(yufull url11\)\)}}}/, /{{{yubl \(yavs \(yufull url12\)\)}}}/, /{{{yubl \(yavd \(yufull url13\)\)}}}/,
+                /{{{yubl \(yavs \(yufull url14\)\)}}}/, /{{{yubl \(yavu \(yufull url15\)\)}}}/, /{{{yubl \(yavu \(yufull url16\)\)}}}/,
+                // test against double quoted, single quoted and unquoted URL Path in attribute href
+                /{{{yavd \(yu path11\)}}}/, /{{{yavs \(yu path12\)}}}/, /{{{yavd \(yu path13\)}}}/,
+                /{{{yavs \(yu path14\)}}}/, /{{{yavu \(yu path15\)}}}/, /{{{yavu \(yu path16\)}}}/,
+                // test against double quoted, single quoted and unquoted after URL ? in attribute href
+                /{{{yavd \(yu kv11\)}}}/, /{{{yavs \(yu kv12\)}}}/, /{{{yavd \(yu kv13\)}}}/,
+                /{{{yavs \(yu kv14\)}}}/, /{{{yavu \(yu kv15\)}}}/, /{{{yavu \(yu kv16\)}}}/,
+                // test against double quoted, single quoted and unquoted URL query string in attribute href
+                /{{{yavd \(yuc q11\)}}}/, /{{{yavd \(yuc q12\)}}}/, /{{{yavd \(yuc q13\)}}}/,
+                /{{{yavs \(yuc q14\)}}}/, /{{{yavs \(yuc q15\)}}}/, /{{{yavs \(yuc q16\)}}}/,
+                /{{{yavd \(yuc q17\)}}}/, /{{{yavd \(yuc q18\)}}}/, /{{{yavs \(yuc q19\)}}}/,
+                /{{{yavs \(yuc q20\)}}}/, /{{{yavu \(yuc q21\)}}}/, /{{{yavu \(yuc q22\)}}}/,
+                /{{{yavu \(yuc q22\)}}}/, /{{{yavu \(yuc q23\)}}}/, /{{{yavu \(yuc q24\)}}}/,
+                /{{{yavu \(yuc q25\)}}}/,
+                // test against double quoted, single quoted and unquoted URL hash in attribute href
+                /{{{yavd \(yuc hash11\)}}}/, /{{{yavs \(yuc hash12\)}}}/, /{{{yavd \(yuc hash13\)}}}/,
+                /{{{yavs \(yuc hash14\)}}}/, /{{{yavu \(yuc hash15\)}}}/, /{{{yavu \(yuc hash16\)}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 003 - add href filters to <form> test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_003.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url11\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url12\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url13\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url14\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url15\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url16\)\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q11\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q14\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q15\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q17\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q18\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q19\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q20\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q21\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q22\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q23\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q24\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q25\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash16\)}}}/);
+            var arr = [ 
+                // test against double quoted, single quoted and unquoted URL in attribute form's action 
+                /{{{yubl \(yavd \(yufull url11\)\)}}}/, /{{{yubl \(yavs \(yufull url12\)\)}}}/, /{{{yubl \(yavd \(yufull url13\)\)}}}/,
+                /{{{yubl \(yavs \(yufull url14\)\)}}}/, /{{{yubl \(yavu \(yufull url15\)\)}}}/, /{{{yubl \(yavu \(yufull url16\)\)}}}/,
+                // test against double quoted, single quoted and unquoted URL Path in attribute form's action 
+                /{{{yavd \(yu path11\)}}}/, /{{{yavs \(yu path12\)}}}/, /{{{yavd \(yu path13\)}}}/,
+                /{{{yavs \(yu path14\)}}}/, /{{{yavu \(yu path15\)}}}/, /{{{yavu \(yu path16\)}}}/,
+                // test against double quoted, single quoted and unquoted after URL ? in attribute form's action
+                /{{{yavd \(yu kv11\)}}}/, /{{{yavs \(yu kv12\)}}}/, /{{{yavd \(yu kv13\)}}}/,
+                /{{{yavs \(yu kv14\)}}}/, /{{{yavu \(yu kv15\)}}}/, /{{{yavu \(yu kv16\)}}}/,
+                // test against double quoted, single quoted and unquoted URL query string in attribute form's action
+                /{{{yavd \(yuc q11\)}}}/, /{{{yavd \(yuc q12\)}}}/, /{{{yavd \(yuc q13\)}}}/,
+                /{{{yavs \(yuc q14\)}}}/, /{{{yavs \(yuc q15\)}}}/, /{{{yavs \(yuc q16\)}}}/,
+                /{{{yavd \(yuc q17\)}}}/, /{{{yavd \(yuc q18\)}}}/, /{{{yavs \(yuc q19\)}}}/,
+                /{{{yavs \(yuc q20\)}}}/, /{{{yavu \(yuc q21\)}}}/, /{{{yavu \(yuc q22\)}}}/,
+                /{{{yavu \(yuc q22\)}}}/, /{{{yavu \(yuc q23\)}}}/, /{{{yavu \(yuc q24\)}}}/,
+                /{{{yavu \(yuc q25\)}}}/,
+                // test against double quoted, single quoted and unquoted URL hash in attribute form's action
+                /{{{yavd \(yuc hash11\)}}}/, /{{{yavs \(yuc hash12\)}}}/, /{{{yavd \(yuc hash13\)}}}/,
+                /{{{yavs \(yuc hash14\)}}}/, /{{{yavu \(yuc hash15\)}}}/, /{{{yavu \(yuc hash16\)}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 004 - add href filters to <img> test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_004.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url11\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url12\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url13\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url14\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url15\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url16\)\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q11\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q14\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q15\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q17\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q18\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q19\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q20\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q21\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q22\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q23\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q24\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q25\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash16\)}}}/);
+            var arr = [ 
+                // test against double quoted, single quoted and unquoted URL in attribute img's src
+                /{{{yubl \(yavd \(yufull url11\)\)}}}/, /{{{yubl \(yavs \(yufull url12\)\)}}}/, /{{{yubl \(yavd \(yufull url13\)\)}}}/,
+                /{{{yubl \(yavs \(yufull url14\)\)}}}/, /{{{yubl \(yavu \(yufull url15\)\)}}}/, /{{{yubl \(yavu \(yufull url16\)\)}}}/,
+                // test against double quoted, single quoted and unquoted URL Path in attribute img's src
+                /{{{yavd \(yu path11\)}}}/, /{{{yavs \(yu path12\)}}}/, /{{{yavd \(yu path13\)}}}/,
+                /{{{yavs \(yu path14\)}}}/, /{{{yavu \(yu path15\)}}}/, /{{{yavu \(yu path16\)}}}/,
+                // test against double quoted, single quoted and unquoted after URL ? in attribute img's src
+                /{{{yavd \(yu kv11\)}}}/, /{{{yavs \(yu kv12\)}}}/, /{{{yavd \(yu kv13\)}}}/,
+                /{{{yavs \(yu kv14\)}}}/, /{{{yavu \(yu kv15\)}}}/, /{{{yavu \(yu kv16\)}}}/,
+                // test against double quoted, single quoted and unquoted URL query string in attribute img's src
+                /{{{yavd \(yuc q11\)}}}/, /{{{yavd \(yuc q12\)}}}/, /{{{yavd \(yuc q13\)}}}/,
+                /{{{yavs \(yuc q14\)}}}/, /{{{yavs \(yuc q15\)}}}/, /{{{yavs \(yuc q16\)}}}/,
+                /{{{yavd \(yuc q17\)}}}/, /{{{yavd \(yuc q18\)}}}/, /{{{yavs \(yuc q19\)}}}/,
+                /{{{yavs \(yuc q20\)}}}/, /{{{yavu \(yuc q21\)}}}/, /{{{yavu \(yuc q22\)}}}/,
+                /{{{yavu \(yuc q22\)}}}/, /{{{yavu \(yuc q23\)}}}/, /{{{yavu \(yuc q24\)}}}/,
+                /{{{yavu \(yuc q25\)}}}/,
+                // test against double quoted, single quoted and unquoted URL hash in attribute img's src
+                /{{{yavd \(yuc hash11\)}}}/, /{{{yavs \(yuc hash12\)}}}/, /{{{yavd \(yuc hash13\)}}}/,
+                /{{{yavs \(yuc hash14\)}}}/, /{{{yavu \(yuc hash15\)}}}/, /{{{yavu \(yuc hash16\)}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 005 - add href filters to <button formaction> test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_005.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url11\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url12\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull url13\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull url14\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url15\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull url16\)\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu path13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu path14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu path16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yu kv13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yu kv14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yu kv16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q11\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q14\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q15\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q16\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q17\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc q18\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q19\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc q20\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q21\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q22\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q23\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q24\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc q25\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash11\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash12\)}}}/);
-            expect(data).to.match(/{{{yavd \(yuc hash13\)}}}/);
-            expect(data).to.match(/{{{yavs \(yuc hash14\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash15\)}}}/);
-            expect(data).to.match(/{{{yavu \(yuc hash16\)}}}/);
+            var arr = [ 
+                // test against double quoted, single quoted and unquoted URL in attribute button's formaction 
+                /{{{yubl \(yavd \(yufull url11\)\)}}}/, /{{{yubl \(yavs \(yufull url12\)\)}}}/, /{{{yubl \(yavd \(yufull url13\)\)}}}/,
+                /{{{yubl \(yavs \(yufull url14\)\)}}}/, /{{{yubl \(yavu \(yufull url15\)\)}}}/, /{{{yubl \(yavu \(yufull url16\)\)}}}/,
+                // test against double quoted, single quoted and unquoted URL Path in attribute button's formaction
+                /{{{yavd \(yu path11\)}}}/, /{{{yavs \(yu path12\)}}}/, /{{{yavd \(yu path13\)}}}/,
+                /{{{yavs \(yu path14\)}}}/, /{{{yavu \(yu path15\)}}}/, /{{{yavu \(yu path16\)}}}/,
+                // test against double quoted, single quoted and unquoted after URL ? in attribute button's formaction
+                /{{{yavd \(yu kv11\)}}}/, /{{{yavs \(yu kv12\)}}}/, /{{{yavd \(yu kv13\)}}}/,
+                /{{{yavs \(yu kv14\)}}}/, /{{{yavu \(yu kv15\)}}}/, /{{{yavu \(yu kv16\)}}}/,
+                // test against double quoted, single quoted and unquoted URL query string in attribute button's formaction
+                /{{{yavd \(yuc q11\)}}}/, /{{{yavd \(yuc q12\)}}}/, /{{{yavd \(yuc q13\)}}}/,
+                /{{{yavs \(yuc q14\)}}}/, /{{{yavs \(yuc q15\)}}}/, /{{{yavs \(yuc q16\)}}}/,
+                /{{{yavd \(yuc q17\)}}}/, /{{{yavd \(yuc q18\)}}}/, /{{{yavs \(yuc q19\)}}}/,
+                /{{{yavs \(yuc q20\)}}}/, /{{{yavu \(yuc q21\)}}}/, /{{{yavu \(yuc q22\)}}}/,
+                /{{{yavu \(yuc q22\)}}}/, /{{{yavu \(yuc q23\)}}}/, /{{{yavu \(yuc q24\)}}}/,
+                /{{{yavu \(yuc q25\)}}}/,
+                // test against double quoted, single quoted and unquoted URL hash in attribute button's formaction
+                /{{{yavd \(yuc hash11\)}}}/, /{{{yavs \(yuc hash12\)}}}/, /{{{yavd \(yuc hash13\)}}}/,
+                /{{{yavs \(yuc hash14\)}}}/, /{{{yavu \(yuc hash15\)}}}/, /{{{yavu \(yuc hash16\)}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
-        it("Filter 006 - add style filters test", function() {
+        it("Filter 006 - add y filters to style attribute test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_006.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y color11}}}/);
-            expect(data).to.match(/{{{y color12}}}/);
-            expect(data).to.match(/{{{y color21}}}/);
-            expect(data).to.match(/{{{y color22}}}/);
-            expect(data).to.match(/{{{y color31}}}/);
-            expect(data).to.match(/{{{y color32}}}/);
-            expect(data).to.match(/{{{y color41}}}/);
-            expect(data).to.match(/{{{y color42}}}/);
-            expect(data).to.match(/{{{y color43}}}/);
-            expect(data).to.match(/{{{y color5}}}/);
-            expect(data).to.match(/{{{y color6}}}/);
-            expect(data).to.match(/{{{y color7}}}/);
-            expect(data).to.match(/{{{y bgcolor1}}}/);
-            expect(data).to.match(/{{{y bgcolor2}}}/);
-            expect(data).to.match(/{{{y bgcolor3}}}/);
-            expect(data).to.match(/{{{y bgcolor5}}}/);
-            expect(data).to.match(/{{{y bgcolor6}}}/);
-            expect(data).to.match(/{{{y bgcolor7}}}/);
+            var arr = [
+                // double quoted
+                /{{{y color11}}}/, /{{{y color12}}}/, /{{{y bgcolor1}}}/, /{{{y color41}}}/,
+                /{{{y color5}}}/, /{{{y bgcolor5}}}/,
+                // single quoted
+                /{{{y color21}}}/, /{{{y color22}}}/, /{{{y bgcolor2}}}/, /{{{y color42}}}/,
+                /{{{y color6}}}/, /{{{y bgcolor6}}}/,
+                // unquoted
+                /{{{y color31}}}/, /{{{y color32}}}/, /{{{y bgcolor3}}}/, /{{{y color43}}}/,
+                /{{{y color7}}}/, /{{{y bgcolor7}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
-        it("Filter 007 - add ycss_quoted and ycss_unquoted filters test", function() {
+        it("Filter 007 - add y filters to style attribute test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_007.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y style1}}}/);
-            expect(data).to.match(/{{{y style2}}}/);
-            expect(data).to.match(/{{{y style3}}}/);
-            expect(data).to.match(/{{{y style4}}}/);
-            expect(data).to.match(/{{{y style5}}}/);
-            expect(data).to.match(/{{{y style6}}}/);
+            var arr = [
+                // double quoted
+                /{{{y style1}}}/, /{{{y style4}}}/,
+                // single quoted
+                /{{{y style2}}}/, /{{{y style5}}}/,
+                // unquoted
+                /{{{y style3}}}/, /{{{y style6}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 008 - add y filters to <script> tag test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_008.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y arg11}}}/);
-            expect(data).to.match(/{{{y arg12}}}/);
-            expect(data).to.match(/{{{y arg13}}}/);
+            var arr = [
+                // single quoted
+                /{{{y arg11}}}/,
+                // double quoted
+                /{{{y arg12}}}/,
+                // unquoted
+                /{{{y arg13}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
-        it("Filter 009 - add yav_xxx filters test", function() {
+        it("Filter 009 - add yavX filters to class attribute test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_009.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yavd class1}}}/);
-            expect(data).to.match(/{{{yavs class2}}}/);
-            expect(data).to.match(/{{{yavu class3}}}/);
-            expect(data).to.match(/{{{yavd class4}}}/);
-            expect(data).to.match(/{{{yavs class5}}}/);
-            expect(data).to.match(/{{{yavu class6}}}/);
-            expect(data).to.match(/{{{yavu class7}}}/);
+            var arr = [
+                // double quoted
+                /{{{yavd class1}}}/, /{{{yavd class4}}}/,
+                // single quoted
+                /{{{yavs class2}}}/, /{{{yavs class5}}}/,
+                // unquoted
+                /{{{yavu class3}}}/, /{{{yavu class6}}}/, /{{{yavu class7}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 010 - add yavu filters to border test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_010.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yavu border}}}/);
+            var arr = [
+                /{{{yavu border}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 011 - add y filter to onclick test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_011.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y arg1}}}/);
-            expect(data).to.match(/{{{y arg2}}}/);
-            expect(data).to.match(/{{{y arg3}}}/);
-            expect(data).to.match(/{{{y arg4}}}/);
-            expect(data).to.match(/{{{y arg5}}}/);
-            expect(data).to.match(/{{{y arg6}}}/);
-            expect(data).to.match(/{{{y arg7}}}/);
-            expect(data).to.match(/{{{y arg8}}}/);
-            expect(data).to.match(/{{{y arg9}}}/);
+            var arr = [
+                // double quoted
+                /{{{y arg1}}}/, /{{{y arg4}}}/,
+                // single quoted
+                /{{{y arg2}}}/, /{{{y arg5}}}/,
+                // unquoted
+                /{{{y arg3}}}/, /{{{y arg6}}}/,
+                // double/single/unqouted line break 
+                /{{{y arg7}}}/, /{{{y arg8}}}/, /{{{y arg9}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 012 - add y filters to onclick test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_012.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y arg1}}}/);
-            expect(data).to.match(/{{{y arg2}}}/);
-            expect(data).to.match(/{{{y arg3}}}/);
-            expect(data).to.match(/{{{y arg4}}}/);
-            expect(data).to.match(/{{{y arg5}}}/);
-            expect(data).to.match(/{{{y arg6}}}/);
-            expect(data).to.match(/{{{y arg7}}}/);
-            expect(data).to.match(/{{{y arg8}}}/);
-            expect(data).to.match(/{{{y arg9}}}/);
-            expect(data).to.match(/{{{y arg10}}}/);
-            expect(data).to.match(/{{{y arg11}}}/);
-            expect(data).to.match(/{{{y arg12}}}/);
-            expect(data).to.match(/{{{y arg13}}}/);
-            expect(data).to.match(/{{{y arg14}}}/);
-            expect(data).to.match(/{{{y arg15}}}/);
-            expect(data).to.match(/{{{y arg16}}}/);
-            expect(data).to.match(/{{{y arg17}}}/);
-            expect(data).to.match(/{{{y arg18}}}/);
-            expect(data).to.match(/{{{y arg19}}}/);
-            expect(data).to.match(/{{{y arg20}}}/);
-            expect(data).to.match(/{{{y arg21}}}/);
-            expect(data).to.match(/{{{y arg22}}}/);
-            expect(data).to.match(/{{{y arg23}}}/);
-            expect(data).to.match(/{{{y arg24}}}/);
-            expect(data).to.match(/{{{y arg25}}}/);
-            expect(data).to.match(/{{{y arg26}}}/);
-            expect(data).to.match(/{{{y arg27}}}/);
+            var arr = [
+                // double quoted with parameter unquoted
+                /{{{y arg1}}}/, /{{{y arg2}}}/, /{{{y arg3}}}/, /{{{y arg4}}}/, /{{{y arg5}}}/, /{{{y arg6}}}/, /{{{y arg7}}}/, /{{{y arg8}}}/, /{{{y arg9}}}/,
+                // single quoted with parameter unquoted
+                /{{{y arg10}}}/, /{{{y arg11}}}/, /{{{y arg12}}}/, /{{{y arg13}}}/, /{{{y arg14}}}/, /{{{y arg15}}}/, /{{{y arg16}}}/, /{{{y arg17}}}/, /{{{y arg18}}}/,
+                // unquoted with parameter unquoted
+                /{{{y arg19}}}/, /{{{y arg20}}}/, /{{{y arg21}}}/, /{{{y arg22}}}/, /{{{y arg23}}}/, /{{{y arg24}}}/, /{{{y arg25}}}/, /{{{y arg26}}}/, /{{{y arg27}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 013 - add y filters to quoted onclick test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_013.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-
-            expect(data).to.match(/{{{y arg10}}}/);
-            expect(data).to.match(/{{{y arg11}}}/);
-            expect(data).to.match(/{{{y arg12}}}/);
-            expect(data).to.match(/{{{y arg13}}}/);
-            expect(data).to.match(/{{{y arg14}}}/);
-            expect(data).to.match(/{{{y arg15}}}/);
-            expect(data).to.match(/{{{y arg16}}}/);
-            expect(data).to.match(/{{{y arg17}}}/);
-            expect(data).to.match(/{{{y arg18}}}/);
-            expect(data).to.match(/{{{y arg19}}}/);
-
-            expect(data).to.match(/{{{y arg20}}}/);
-            expect(data).to.match(/{{{y arg21}}}/);
-            expect(data).to.match(/{{{y arg22}}}/);
-            expect(data).to.match(/{{{y arg23}}}/);
-            expect(data).to.match(/{{{y arg24}}}/);
-            expect(data).to.match(/{{{y arg25}}}/);
-            expect(data).to.match(/{{{y arg26}}}/);
-            expect(data).to.match(/{{{y arg27}}}/);
-            expect(data).to.match(/{{{y arg28}}}/);
-            expect(data).to.match(/{{{y arg29}}}/);
-
-            expect(data).to.match(/{{{y arg30}}}/);
-            expect(data).to.match(/{{{y arg31}}}/);
-            expect(data).to.match(/{{{y arg32}}}/);
-            expect(data).to.match(/{{{y arg33}}}/);
-            expect(data).to.match(/{{{y arg34}}}/);
-            expect(data).to.match(/{{{y arg35}}}/);
-
-            expect(data).to.match(/{{{y arg36}}}/);
-            expect(data).to.match(/{{{y arg37}}}/);
-            expect(data).to.match(/{{{y arg38}}}/);
-            expect(data).to.match(/{{{y arg39}}}/);
-
-            expect(data).to.match(/{{{y arg40}}}/);
-            expect(data).to.match(/{{{y arg41}}}/);
-            expect(data).to.match(/{{{y arg42}}}/);
-            expect(data).to.match(/{{{y arg43}}}/);
-            expect(data).to.match(/{{{y arg44}}}/);
-            expect(data).to.match(/{{{y arg45}}}/);
+            var arr = [
+                // double quoted with parameter unquoted
+                /{{{y arg10}}}/, /{{{y arg11}}}/, /{{{y arg12}}}/,
+                // single quoted with parameter unquoted
+                /{{{y arg13}}}/, /{{{y arg14}}}/, /{{{y arg15}}}/,
+                // double quoted with parameter unquoted (with space)
+                /{{{y arg16}}}/, /{{{y arg17}}}/,
+                // single quoted with parameter unquoted (with space)
+                /{{{y arg18}}}/, /{{{y arg19}}}/,
+                // double quoted with parameter quoted
+                /{{{y arg20}}}/, /{{{y arg21}}}/, /{{{y arg22}}}/,
+                // single quoted with parameter quoted
+                /{{{y arg23}}}/, /{{{y arg24}}}/, /{{{y arg25}}}/,
+                // double quoted with parameter quoted (with space)
+                /{{{y arg26}}}/, /{{{y arg27}}}/,
+                // single quoted with parameter quoted (with space)
+                /{{{y arg28}}}/, /{{{y arg29}}}/,
+                // double quoted with parameter slash quoted
+                /{{{y arg30}}}/, /{{{y arg31}}}/, /{{{y arg32}}}/,
+                // single quoted with parameter slash quoted
+                /{{{y arg33}}}/, /{{{y arg34}}}/, /{{{y arg35}}}/,
+                // double quoted with parameter slash quoted (with space)
+                /{{{y arg36}}}/, /{{{y arg37}}}/,
+                // single quoted with parameter slash quoted (with space)
+                /{{{y arg38}}}/, /{{{y arg39}}}/,
+                // double quoted 
+                /{{{y arg40}}}/, /{{{y arg43}}}/,
+                // single quoted 
+                /{{{y arg41}}}/, /{{{y arg44}}}/,
+                // unquoted 
+                /{{{y arg42}}}/, /{{{y arg45}}}/,
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 014 - add y filters unquoted onclick test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_014.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y arg10}}}/);
-            expect(data).to.match(/{{{y arg11}}}/);
-            expect(data).to.match(/{{{y arg12}}}/);
-            expect(data).to.match(/{{{y arg13}}}/);
-            expect(data).to.match(/{{{y arg14}}}/);
-
-            expect(data).to.match(/{{{y arg20}}}/);
-            expect(data).to.match(/{{{y arg21}}}/);
-            expect(data).to.match(/{{{y arg22}}}/);
-            expect(data).to.match(/{{{y arg23}}}/);
-            expect(data).to.match(/{{{y arg24}}}/);
-            expect(data).to.match(/{{{y arg25}}}/);
-            expect(data).to.match(/{{{y arg26}}}/);
+            var arr = [
+                // unquoted with parameter unquoted
+                /{{{y arg10}}}/, /{{{y arg11}}}/, /{{{y arg12}}}/, /{{{y arg13}}}/, /{{{y arg14}}}/,
+                // unquoted with parameter single / double quoted
+                /{{{y arg20}}}/, /{{{y arg21}}}/, /{{{y arg22}}}/, 
+                // unquoted with parameter single quoted
+                /{{{y arg23}}}/, /{{{y arg24}}}/,
+                // unquoted with parameter double quoted
+                /{{{y arg25}}}/, /{{{y arg26}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 015 - add y filters to <script> block", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_015.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y value1}}}/);
-            expect(data).to.match(/{{{y value2}}}/);
-            expect(data).to.match(/{{{y value3}}}/);
+            var arr = [
+                // double quoted
+                /{{{y value1}}}/, 
+                // single quoted
+                /{{{y value2}}}/, 
+                // unquoted
+                /{{{y value3}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 016 - add y filter to <style> block", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_016.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y fontsize}}}/);
+            var arr = [
+                /{{{y fontsize}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 018 - add y filters to quoted href test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_018.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-
-            expect(data).to.match(/{{{y arg10}}}/);
-            expect(data).to.match(/{{{y arg11}}}/);
-            expect(data).to.match(/{{{y arg12}}}/);
-            expect(data).to.match(/{{{y arg13}}}/);
-            expect(data).to.match(/{{{y arg14}}}/);
-            expect(data).to.match(/{{{y arg15}}}/);
-            expect(data).to.match(/{{{y arg16}}}/);
-            expect(data).to.match(/{{{y arg17}}}/);
-            expect(data).to.match(/{{{y arg18}}}/);
-            expect(data).to.match(/{{{y arg19}}}/);
-
-            expect(data).to.match(/{{{y arg20}}}/);
-            expect(data).to.match(/{{{y arg21}}}/);
-            expect(data).to.match(/{{{y arg22}}}/);
-            expect(data).to.match(/{{{y arg23}}}/);
-            expect(data).to.match(/{{{y arg24}}}/);
-            expect(data).to.match(/{{{y arg25}}}/);
-            expect(data).to.match(/{{{y arg26}}}/);
-            expect(data).to.match(/{{{y arg27}}}/);
-            expect(data).to.match(/{{{y arg28}}}/);
-            expect(data).to.match(/{{{y arg29}}}/);
-
-            expect(data).to.match(/{{{y arg30}}}/);
-            expect(data).to.match(/{{{y arg31}}}/);
-            expect(data).to.match(/{{{y arg32}}}/);
-            expect(data).to.match(/{{{y arg33}}}/);
-            expect(data).to.match(/{{{y arg34}}}/);
-            expect(data).to.match(/{{{y arg35}}}/);
-
-            expect(data).to.match(/{{{y arg36}}}/);
-            expect(data).to.match(/{{{y arg37}}}/);
-            expect(data).to.match(/{{{y arg38}}}/);
-            expect(data).to.match(/{{{y arg39}}}/);
-
-            expect(data).to.match(/{{{y vbarg10}}}/);
-            expect(data).to.match(/{{{y vbarg11}}}/);
-            expect(data).to.match(/{{{y vbarg12}}}/);
-            expect(data).to.match(/{{{y vbarg13}}}/);
-            expect(data).to.match(/{{{y vbarg14}}}/);
-            expect(data).to.match(/{{{y vbarg15}}}/);
-            expect(data).to.match(/{{{y vbarg16}}}/);
-            expect(data).to.match(/{{{y vbarg17}}}/);
-            expect(data).to.match(/{{{y vbarg18}}}/);
-            expect(data).to.match(/{{{y vbarg19}}}/);
-
-            expect(data).to.match(/{{{y vbarg20}}}/);
-            expect(data).to.match(/{{{y vbarg21}}}/);
-            expect(data).to.match(/{{{y vbarg22}}}/);
-            expect(data).to.match(/{{{y vbarg23}}}/);
-            expect(data).to.match(/{{{y vbarg24}}}/);
-            expect(data).to.match(/{{{y vbarg25}}}/);
-            expect(data).to.match(/{{{y vbarg26}}}/);
-            expect(data).to.match(/{{{y vbarg27}}}/);
-            expect(data).to.match(/{{{y vbarg28}}}/);
-            expect(data).to.match(/{{{y vbarg29}}}/);
-
-            expect(data).to.match(/{{{y vbarg30}}}/);
-            expect(data).to.match(/{{{y vbarg31}}}/);
-            expect(data).to.match(/{{{y vbarg32}}}/);
-            expect(data).to.match(/{{{y vbarg33}}}/);
-            expect(data).to.match(/{{{y vbarg34}}}/);
-            expect(data).to.match(/{{{y vbarg35}}}/);
-
-            expect(data).to.match(/{{{y vbarg36}}}/);
-            expect(data).to.match(/{{{y vbarg37}}}/);
-            expect(data).to.match(/{{{y vbarg38}}}/);
-            expect(data).to.match(/{{{y vbarg39}}}/);
-
-            expect(data).to.match(/{{{yubl \(yavd \(yufull arg40\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull arg41\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull arg42\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull arg43\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavs \(yufull arg44\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull arg45\)\)}}}/);
+            var arr = [
+                // double quoted with parameter unquoted
+                /{{{y arg10}}}/, /{{{y arg11}}}/, /{{{y arg12}}}/,
+                // single quoted with parameter unquoted
+                /{{{y arg13}}}/, /{{{y arg14}}}/, /{{{y arg15}}}/,
+                // double quoted with parameter unquoted (with space)
+                /{{{y arg16}}}/, /{{{y arg17}}}/,
+                // single quoted with parameter unquoted (with space)
+                /{{{y arg18}}}/, /{{{y arg19}}}/,
+                // double quoted with parameter quoted
+                /{{{y arg20}}}/, /{{{y arg21}}}/, /{{{y arg22}}}/,
+                // single quoted with parameter quoted
+                /{{{y arg23}}}/, /{{{y arg24}}}/, /{{{y arg25}}}/,
+                // double quoted with parameter quoted (with space)
+                /{{{y arg26}}}/, /{{{y arg27}}}/,
+                // single quoted with parameter quoted (with space)
+                /{{{y arg28}}}/, /{{{y arg29}}}/,
+                // double quoted with parameter slash quoted
+                /{{{y arg30}}}/, /{{{y arg31}}}/, /{{{y arg32}}}/,
+                // single quoted with parameter slash quoted
+                /{{{y arg33}}}/, /{{{y arg34}}}/, /{{{y arg35}}}/,
+                // double quoted with parameter slash quoted (with space)
+                /{{{y arg36}}}/, /{{{y arg37}}}/,
+                // single quoted with parameter slash quoted (with space)
+                /{{{y arg38}}}/, /{{{y arg39}}}/,
+                // double quoted with parameter unquoted
+                /{{{y vbarg10}}}/, /{{{y vbarg11}}}/, /{{{y vbarg12}}}/,
+                // single quoted with parameter unquoted
+                /{{{y vbarg13}}}/, /{{{y vbarg14}}}/, /{{{y vbarg15}}}/,
+                // double quoted with parameter unquoted (with space)
+                /{{{y vbarg16}}}/, /{{{y vbarg17}}}/,
+                // single quoted with parameter unquoted (with space)
+                /{{{y vbarg18}}}/, /{{{y vbarg19}}}/,
+                // double quoted with parameter quoted
+                /{{{y vbarg20}}}/, /{{{y vbarg21}}}/, /{{{y vbarg22}}}/,
+                // single quoted with parameter quoted
+                /{{{y vbarg23}}}/, /{{{y vbarg24}}}/, /{{{y vbarg25}}}/,
+                // double quoted with parameter quoted (with space)
+                /{{{y vbarg26}}}/, /{{{y vbarg27}}}/,
+                // single quoted with parameter quoted (with space)
+                /{{{y vbarg28}}}/, /{{{y vbarg29}}}/,
+                // double quoted with parameter slash quoted
+                /{{{y vbarg30}}}/, /{{{y vbarg31}}}/, /{{{y vbarg32}}}/,
+                // single quoted with parameter slash quoted
+                /{{{y vbarg33}}}/, /{{{y vbarg34}}}/, /{{{y vbarg35}}}/,
+                // double quoted with parameter slash quoted (with space)
+                /{{{y vbarg36}}}/, /{{{y vbarg37}}}/,
+                // single quoted with parameter slash quoted (with space)
+                /{{{y vbarg38}}}/, /{{{y vbarg39}}}/,
+                // double quoted
+                /{{{yubl \(yavd \(yufull arg40\)\)}}}/, /{{{yubl \(yavd \(yufull arg43\)\)}}}/,
+                // single quoted
+                /{{{yubl \(yavs \(yufull arg41\)\)}}}/, /{{{yubl \(yavs \(yufull arg44\)\)}}}/,
+                // unquoted
+                /{{{yubl \(yavu \(yufull arg42\)\)}}}/, /{{{yubl \(yavu \(yufull arg45\)\)}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 019 - add y filters unquoted href test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_019.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{y arg10}}}/);
-            expect(data).to.match(/{{{y arg11}}}/);
-            expect(data).to.match(/{{{y arg12}}}/);
-            expect(data).to.match(/{{{y arg13}}}/);
-            expect(data).to.match(/{{{y arg14}}}/);
-
-            expect(data).to.match(/{{{y arg20}}}/);
-            expect(data).to.match(/{{{y arg21}}}/);
-            expect(data).to.match(/{{{y arg22}}}/);
-            expect(data).to.match(/{{{y arg23}}}/);
-            expect(data).to.match(/{{{y arg24}}}/);
-            expect(data).to.match(/{{{y arg25}}}/);
-            expect(data).to.match(/{{{y arg26}}}/);
-
-            expect(data).to.match(/{{{y vbarg10}}}/);
-            expect(data).to.match(/{{{y vbarg11}}}/);
-            expect(data).to.match(/{{{y vbarg12}}}/);
-            expect(data).to.match(/{{{y vbarg13}}}/);
-            expect(data).to.match(/{{{y vbarg14}}}/);
-
-            expect(data).to.match(/{{{y vbarg20}}}/);
-            expect(data).to.match(/{{{y vbarg21}}}/);
-            expect(data).to.match(/{{{y vbarg22}}}/);
-            expect(data).to.match(/{{{y vbarg23}}}/);
-            expect(data).to.match(/{{{y vbarg24}}}/);
-            expect(data).to.match(/{{{y vbarg25}}}/);
-            expect(data).to.match(/{{{y vbarg26}}}/);
+            var arr = [
+                // unquoted with parameter unquoted
+                /{{{y arg10}}}/, /{{{y arg11}}}/, /{{{y arg12}}}/, /{{{y arg13}}}/, /{{{y arg14}}}/,
+                // unquoted with parameter double / single unquoted
+                /{{{y arg20}}}/, /{{{y arg21}}}/, /{{{y arg22}}}/, /{{{y arg23}}}/, /{{{y arg24}}}/, /{{{y arg25}}}/, /{{{y arg26}}}/,
+                // unquoted with parameter unquoted (vbscript)
+                /{{{y vbarg10}}}/, /{{{y vbarg11}}}/, /{{{y vbarg12}}}/, /{{{y vbarg13}}}/, /{{{y vbarg14}}}/,
+                // unquoted with parameter double / single unquoted (vbscript)
+                /{{{y vbarg20}}}/, /{{{y vbarg21}}}/, /{{{y vbarg22}}}/, /{{{y vbarg23}}}/, /{{{y vbarg24}}}/, /{{{y vbarg25}}}/, /{{{y vbarg26}}}/,
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter 020 - add yd filters to RCDATA test", function() {
             var file = "./tests/samples/files/handlebarsjs_filter_020.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd title}}}/);
+            var arr = [
+                /{{{yd title}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Filter - subexpression format test", function() {
@@ -515,14 +413,19 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             var data = "<html><title>{{title}}</title></html>";
             t1.contextualize(data);
             var output = t1.getBuffer().join('');
-            expect(output).to.match(/{{{yd title}}}/);
+            var arr = [
+                /{{{yd title}}}/
+            ];
+            utils.testArrMatch(output, arr);
 
             var t2 = new ContextParserHandlebars(false);
             var data = "<a href='{{url}}'>link</a>";
             t2.contextualize(data);
             var output = t2.getBuffer().join('');
-            expect(output).to.match(/{{{yubl \(yavs \(yufull url\)\)}}}/);
+            var arr = [
+                /{{{yubl \(yavs \(yufull url\)\)}}}/
+            ];
+            utils.testArrMatch(output, arr);
         });
     });
-
 }());

--- a/tests/unit/run-handlebars-spec.js
+++ b/tests/unit/run-handlebars-spec.js
@@ -13,7 +13,123 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         expect = require('expect.js'),
         handlebars = require('handlebars');
 
-    describe("Vanillia Handlebars parsing test suite", function() {
+    describe("Vanilla Handlebars parsing test suite", function() {
+
+        it("handlebars {{expression}} test", function() {
+            var t = '{{expression}}';
+            var ast = handlebars.parse(t);
+            expect(ast.statements[0].type).to.equal('mustache');
+
+            t = '{{expression}} }';
+            ast = handlebars.parse(t);
+	    expect(ast.statements[0].type).to.equal('mustache');
+
+            t = '{ {expression}}';
+            ast = handlebars.parse(t);
+	    expect(ast.statements[0].type).to.equal('content');
+
+            t = '{{express\rion}}';
+            ast = handlebars.parse(t);
+	    expect(ast.statements[0].type).to.equal('mustache');
+	    expect(ast.statements[0].params[0].string).to.equal('ion');
+	    expect(ast.statements[0].isHelper).to.equal(true);
+
+            t = '{{express\nion}}';
+            ast = handlebars.parse(t);
+	    expect(ast.statements[0].type).to.equal('mustache');
+	    expect(ast.statements[0].params[0].string).to.equal('ion');
+	    expect(ast.statements[0].isHelper).to.equal(true);
+        });
+
+        it("handlebars invalid {{expression}} test", function() {
+            var t = '{{expression}}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{expression} }';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{   {expression}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{   }expression}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+        });
+
+        it("handlebars {{{raw expression}}} test", function() {
+            var t = '{{{expression}}}';
+            var ast = handlebars.parse(t);
+            expect(ast.statements[0].type).to.equal('mustache');
+
+            t = '{{{expression}}} }';
+            ast = handlebars.parse(t);
+	    expect(ast.statements[0].type).to.equal('mustache');
+
+            t = '{ { {expression}}}';
+            ast = handlebars.parse(t);
+	    expect(ast.statements[0].type).to.equal('content');
+        });
+
+        it("handlebars invalid {{{raw expression}}} test", function() {
+            var t = '{{ {expression}}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{ {{expression}}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{{expression}} }';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{{expression} }}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+            t = '{{{}}}';
+            try {
+                var ast = handlebars.parse(t);
+                expect(false).to.equal(true);
+            } catch (err) {
+                expect(true).to.equal(true);
+            }
+        });
 
         it("handlebars {{#if}} {{!-- comment --}} {{/if}} parsing test", function() {
             var t = '{{#if}}xxx{{!-- comment --}}yyy{{/if}}';
@@ -107,6 +223,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         it("handlebars {{#if}} {{else}} {{/if}} parsing test 2", function() {
             var t = '{{# if}}xxx{{ else }}yyy{{/ if}}';
             var ast = handlebars.parse(t);
+            expect(ast.statements[0].mustache.id.string).to.equal('if');
+            expect(ast.statements[0].program.statements[0].string).to.equal('xxx');
+            expect(ast.statements[0].inverse.statements[0].string).to.equal('yyy');
+
+            t = '{{# if }}xxx{{ else }}yyy{{/ if}}';
+            ast = handlebars.parse(t);
             expect(ast.statements[0].mustache.id.string).to.equal('if');
             expect(ast.statements[0].program.statements[0].string).to.equal('xxx');
             expect(ast.statements[0].inverse.statements[0].string).to.equal('yyy');

--- a/tests/unit/run-handlebars-spec.js
+++ b/tests/unit/run-handlebars-spec.js
@@ -9,126 +9,87 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 */
 (function () {
 
-    var mocha = require("mocha"),
-        expect = require('expect.js'),
+    mocha = require("mocha");
+    var expect = require('chai').expect,
         handlebars = require('handlebars');
 
     describe("Vanilla Handlebars parsing test suite", function() {
 
         it("handlebars {{expression}} test", function() {
-            var t = '{{expression}}';
-            var ast = handlebars.parse(t);
-            expect(ast.statements[0].type).to.equal('mustache');
+            [
+                '{{expression}}',
+                '{{expression}} }',
+            ].forEach(function(t) {
+                var ast = handlebars.parse(t);
+	        expect(ast.statements[0].type).to.equal('mustache');
+            });
+            [
+                '{ {expression}}',
+            ].forEach(function(t) {
+                var ast = handlebars.parse(t);
+	        expect(ast.statements[0].type).to.equal('content');
+            });
+        });
 
-            t = '{{expression}} }';
-            ast = handlebars.parse(t);
-	    expect(ast.statements[0].type).to.equal('mustache');
-
-            t = '{ {expression}}';
-            ast = handlebars.parse(t);
-	    expect(ast.statements[0].type).to.equal('content');
-
-            t = '{{express\rion}}';
-            ast = handlebars.parse(t);
-	    expect(ast.statements[0].type).to.equal('mustache');
-	    expect(ast.statements[0].params[0].string).to.equal('ion');
-	    expect(ast.statements[0].isHelper).to.equal(true);
-
-            t = '{{express\nion}}';
-            ast = handlebars.parse(t);
-	    expect(ast.statements[0].type).to.equal('mustache');
-	    expect(ast.statements[0].params[0].string).to.equal('ion');
-	    expect(ast.statements[0].isHelper).to.equal(true);
+        it("handlebars {{expression}} subexpression with \r\n test", function() {
+            [
+                '{{expression\rion}}',
+                '{{expression\nion}}',
+                '{{expression\r\nion}}',
+            ].forEach(function(t) {
+                var ast = handlebars.parse(t);
+	        expect(ast.statements[0].type).to.equal('mustache');
+	        expect(ast.statements[0].params[0].string).to.equal('ion');
+	        expect(ast.statements[0].isHelper).to.equal(true);
+            });
         });
 
         it("handlebars invalid {{expression}} test", function() {
-            var t = '{{expression}}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{expression} }';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{   {expression}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{   }expression}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
+            [
+                '{ {anything}}', 
+                '{{anything}', '{{anything} }', '{{anything}}}',
+                '{{    {anything}}', '{{    }anything}}',
+                '{{}}'
+            ].forEach(function(e) {
+                try {
+                    var ast = handlebars.parse(e);
+                    expect(false).to.equal(true);
+                } catch (err) {
+                    expect(true).to.equal(true);
+                }
+            });
         });
 
         it("handlebars {{{raw expression}}} test", function() {
-            var t = '{{{expression}}}';
-            var ast = handlebars.parse(t);
-            expect(ast.statements[0].type).to.equal('mustache');
-
-            t = '{{{expression}}} }';
-            ast = handlebars.parse(t);
-	    expect(ast.statements[0].type).to.equal('mustache');
-
-            t = '{ { {expression}}}';
-            ast = handlebars.parse(t);
-	    expect(ast.statements[0].type).to.equal('content');
+            [
+                '{{{expression}}}',
+                '{{{expression}}} }',
+            ].forEach(function(t) {
+                var ast = handlebars.parse(t);
+	        expect(ast.statements[0].type).to.equal('mustache');
+            });
+            [
+                '{ { {expression}}}',
+            ].forEach(function(t) {
+                var ast = handlebars.parse(t);
+	        expect(ast.statements[0].type).to.equal('content');
+            });
         });
 
         it("handlebars invalid {{{raw expression}}} test", function() {
-            var t = '{{ {expression}}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{ {{expression}}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{{expression}} }';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{{expression} }}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
-            t = '{{{}}}';
-            try {
-                var ast = handlebars.parse(t);
-                expect(false).to.equal(true);
-            } catch (err) {
-                expect(true).to.equal(true);
-            }
+            [
+                '{ {{anything}}}', '{{ {anything}}}',
+                '{{{anything}', '{{{anything}}', '{{{anything}}}}',
+                '{{{    {anything}}}', '{{{    }anything}}}',
+                '{{{}}}'
+            ].forEach(function(e) {
+                try {
+                    var ast = handlebars.parse(e);
+                    expect(false).to.equal(true);
+                } catch (err) {
+                    expect(true).to.equal(true);
+                }
+            });
         });
 
         it("handlebars {{#if}} {{!-- comment --}} {{/if}} parsing test", function() {

--- a/tests/unit/run-states-spec.js
+++ b/tests/unit/run-states-spec.js
@@ -10,7 +10,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 (function () {
 
     require("mocha");
-    var assert = require("assert"),
+    var expect = require("chai").expect,
         Parser = require("context-parser").Parser;
 
     describe('HTML5 Context Parser html5 state test suite', function(){
@@ -28,7 +28,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 	    var html = '<div id="1" {';
             p1.contextualize(html);
             var states = p1.getStates();
-            assert.equal(states.toString(), '1,8,10,10,10,34,35,35,37,38,38,42,34,35');
+            expect(states.toString()).to.equal('1,8,10,10,10,34,35,35,37,38,38,42,34,35');
         });
 
         /* 
@@ -44,7 +44,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 	    var html = '<option value="1" selected {';
             p1.contextualize(html);
             var states = p1.getStates();
-            assert.equal(states.toString(), '1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,38,38,42,34,35,35,35,35,35,35,35,35,36,35');
+            expect(states.toString()).to.equal('1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,38,38,42,34,35,35,35,35,35,35,35,35,36,35');
         });
 
         /* 
@@ -60,7 +60,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 	    var html = '<option value={';
             p1.contextualize(html);
             var states = p1.getStates();
-            assert.equal(states.toString(), '1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,40');
+            expect(states.toString()).to.equal('1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,40');
         });
 
         /* 
@@ -76,7 +76,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 	    var html = '<option value="{';
             p1.contextualize(html);
             var states = p1.getStates();
-            assert.equal(states.toString(), '1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,38,38');
+            expect(states.toString()).to.equal('1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,38,38');
         });
 
         /* 
@@ -92,7 +92,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 	    var html = '<option value=\'{';
             p1.contextualize(html);
             var states = p1.getStates();
-            assert.equal(states.toString(), '1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,39,39');
+            expect(states.toString()).to.equal('1,8,10,10,10,10,10,10,34,35,35,35,35,35,37,39,39');
         });
 
         /* 
@@ -109,7 +109,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 	    var html = '<div id="1"{';
             p1.contextualize(html);
             var states = p1.getStates();
-            assert.equal(states.toString(), '1,8,10,10,10,34,35,35,37,38,38,34,35');
+            expect(states.toString()).to.equal('1,8,10,10,10,34,35,35,37,38,38,34,35');
         });
 
     });

--- a/tests/unit/run-templates-spec.js
+++ b/tests/unit/run-templates-spec.js
@@ -9,82 +9,113 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 */
 (function () {
 
-    var mocha = require("mocha"),
-        fs = require('fs'),
-        expect = require('expect.js');
+    require("mocha");
+    var fs = require('fs'),
+        utils = require('../utils.js'),
+        expect = require('chai').expect;
 
     describe("Handlebars Context Parser template test suite", function() {
 
         it("Template 000 - basic {{expression}} test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_000.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd name}}}/);
+            var arr = [
+                /{{{yd name}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 001 - basic raw {{{expression}}} test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_001.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{name}}}/);
+            var arr = [
+                /{{{name}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 002 - basic block {{#expression}} {{/expression}} test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_002.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{#list people}}{{{yd firstName}}} {{{yd lastName}}}{{\/list}}/);
+            var arr = [
+                /{{#list people}}{{{yd firstName}}} {{{yd lastName}}}{{\/list}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 003 - {{ expression}} with space test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_003.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd  name}}}/);
+            var arr = [
+                /{{{yd  name}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 004 - broken open brace {  {expression}} test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_004.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{  {name}}/);
+            var arr = [
+                /{  {name}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 005 - {{#with}} helper test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_005.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{#with story}}/);
-            expect(data).to.match(/<div class="intro">{{{yd intro}}}<\/div>/);
-            expect(data).to.match(/<div class="body">{{{yd body}}}<\/div>/);
-            expect(data).to.match(/{{\/with}}/);
+            var arr = [
+                /{{#with story}}/,
+                /<div class="intro">{{{yd intro}}}<\/div>/,
+                /<div class="body">{{{yd body}}}<\/div>/,
+                /{{\/with}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 006 - {{#with}} helper with space test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_006.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{#   with story}}/);
-            expect(data).to.match(/<div class="intro">{{{yd intro}}}<\/div>/);
-            expect(data).to.match(/<div class="body">{{{yd body}}}<\/div>/);
-            expect(data).to.match(/{{\/with}}/);
+            var arr = [
+                /{{#   with story}}/,
+                /<div class="intro">{{{yd intro}}}<\/div>/,
+                /<div class="body">{{{yd body}}}<\/div>/,
+                /{{\/with}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 007 - comment markup test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_007.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{!--    comment1  --}}/);
-            expect(data).to.match(/{{!--    comment2  }}/);
-            expect(data).to.match(/{{! comment3 }}/);
+            var arr = [
+                /{{!--    comment1  --}}/,
+                /{{!--    comment2  }}/,
+                /{{! comment3 }}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 008 - {{>partial}} template test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_008.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{>html_header}}/);
-            expect(data).to.match(/{{>header}}/);
-            expect(data).to.match(/{{>footer}}/);
-            expect(data).to.match(/{{>html_footer}}/);
+            var arr = [
+                /{{>html_header}}/,
+                /{{>header}}/,
+                /{{>footer}}/,
+                /{{>html_footer}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 009 - subexpression test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_009.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd \(outer-helper1 \(inner-helper1 'abc'\) 'def'\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull \(outer-helper2 \(inner-helper2 'abc'\) 'def'\)\)\)}}}/);
+            var arr = [
+                /{{{yd \(outer-helper1 \(inner-helper1 'abc'\) 'def'\)}}}/,
+                /{{{yubl \(yavd \(yufull \(outer-helper2 \(inner-helper2 'abc'\) 'def'\)\)\)}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 010 - {{#if}} statement with yd, yattribute_value_quoted, yURI and y test", function() {
@@ -108,99 +139,103 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         it("Template 010 - known filter {{else}} test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_010.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{else}}/);
+            var arr = [
+                /{{else}}/
+            ];
+            utils.testArrMatch(data, arr);
             expect(data).to.not.match(/{{{else}}}/);
         });
 
         it("Template 011 - attribute name state test", function() {
             var file = "./tests/samples/files/handlebarsjs_template_011.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yavd classname}}}/);
-            expect(data).to.match(/{{{yavd index_active}}}/);
-            expect(data).to.match(/{{{yavd safejstemplating_active1}}}/);
-            expect(data).to.match(/{{{y safejstemplating_active2}}}/);
+            var arr = [
+                /{{{yavd classname}}}/,
+                /{{{yavd index_active}}}/,
+                /{{{yavd safejstemplating_active1}}}/,
+                /{{{y safejstemplating_active2}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 012 - quoted attribute value after unquoted attribute test ", function() {
             var file = "./tests/samples/files/handlebarsjs_template_012.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd html}}/);
-            expect(data).to.match(/{{{yavu SELECTED1}}}/);
-            expect(data).to.match(/{{{yavu SELECTED21}}}/);
-            expect(data).to.match(/{{{yavu SELECTED22}}}/);
-            expect(data).to.match(/{{{yavd SELECTED3}}}/);
-            expect(data).to.match(/{{{yavd SELECTED4}}}/);
-            expect(data).to.match(/{{{yd NAME1}}}/);
-            expect(data).to.match(/{{{yd NAME2}}}/);
-            expect(data).to.match(/{{{yd NAME3}}}/);
-            expect(data).to.match(/{{{yd NAME4}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull URL1\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavd \(yufull URL2\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull URL3\)\)}}}/);
-            expect(data).to.match(/{{{yubl \(yavu \(yufull URL4\)\)}}}/);
-            expect(data).to.match(/{{{yc COMMENT1}}}/);
-            expect(data).to.match(/{{{yc COMMENT2}}}/);
-            expect(data).to.match(/{{{y ATTR1}}}/);
+            var arr = [
+                /{{{yd html}}}/,
+                /{{{yavu SELECTED1}}}/,
+                /{{{yavu SELECTED21}}}/,
+                /{{{yavu SELECTED22}}}/,
+                /{{{yavd SELECTED3}}}/,
+                /{{{yavd SELECTED4}}}/,
+                /{{{yd NAME1}}}/, /{{{yd NAME2}}}/, /{{{yd NAME3}}}/, /{{{yd NAME4}}}/,
+                /{{{yubl \(yavd \(yufull URL1\)\)}}}/, /{{{yubl \(yavd \(yufull URL2\)\)}}}/, /{{{yubl \(yavu \(yufull URL3\)\)}}}/, /{{{yubl \(yavu \(yufull URL4\)\)}}}/,
+                /{{{yc COMMENT1}}}/, /{{{yc COMMENT2}}}/,
+                /{{{y ATTR1}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 013 - {{#if}} statement test with correct filter", function() {
             var file = "./tests/samples/files/handlebarsjs_template_013.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
             expect(data).to.match(/{{{yd placeholder3}}}/);
+            var arr = [
+                /{{{yd placeholder3}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 014 - {{#if}} statement test with output markup within if statement", function() {
             var file = "./tests/samples/files/handlebarsjs_template_014.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yd placeholder1}}}/);
-            expect(data).to.match(/{{{yd placeholder2}}}/);
-            expect(data).to.match(/{{{yd placeholder3}}}/);
+            var arr = [
+                /{{{yd placeholder1}}}/,
+                /{{{yd placeholder2}}}/,
+                /{{{yd placeholder3}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 015 - {{#if}} statement test with raw expression markup within if statement", function() {
             var file = "./tests/samples/files/handlebarsjs_template_015.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{placeholder1}}}/);
-            expect(data).to.match(/{{{placeholder2}}}/);
-            expect(data).to.match(/{{{yd placeholder3}}}/);
+            var arr = [
+                /{{{placeholder1}}}/,
+                /{{{placeholder2}}}/,
+                /{{{yd placeholder3}}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 016 - {{#if}} statement test with iteration expression markup within if statement", function() {
             var file = "./tests/samples/files/handlebarsjs_template_016.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yavd valueA}}}/);
-            expect(data).to.match(/{{{yd firstName11}}}/);
-            expect(data).to.match(/{{{yd lastName12}}}/);
-            expect(data).to.match(/{{{yd placeholderA}}}/);
-
-            expect(data).to.match(/{{{yavd valueB}}}/);
-            expect(data).to.match(/{{{yd firstName21}}}/);
-            expect(data).to.match(/{{{yd lastName22}}}/);
-            expect(data).to.match(/{{{yd placeholderB}}}/);
-
-            expect(data).to.match(/{{{yavd valueC}}}/);
-            expect(data).to.match(/{{{yd firstName31}}}/);
-            expect(data).to.match(/{{{yd lastName32}}}/);
-            expect(data).to.match(/{{{yd placeholderC}}}/);
-
-            expect(data).to.match(/{{{yavd valueD}}}/);
-            expect(data).to.match(/{{{yd firstName41}}}/);
-            expect(data).to.match(/{{{yd lastName42}}}/);
-            expect(data).to.match(/{{{yd placeholderD}}}/);
-
-            expect(data).to.match(/{{{yavd valueE}}}/);
-            expect(data).to.match(/{{{yd firstName51}}}/);
-            expect(data).to.match(/{{{yd lastName52}}}/);
-            expect(data).to.match(/{{{yd placeholderE}}}/);
+            var arr = [
+                // {{{#list}}
+                /{{{yavd valueA}}}/, /{{{yd firstName11}}}/, /{{{yd lastName12}}}/, /{{{yd placeholderA}}}/,
+                // {{{#each}}
+                /{{{yavd valueB}}}/, /{{{yd firstName21}}}/, /{{{yd lastName22}}}/, /{{{yd placeholderB}}}/,
+                // {{{#with}}
+                /{{{yavd valueC}}}/, /{{{yd firstName31}}}/, /{{{yd lastName32}}}/, /{{{yd placeholderC}}}/,
+                // {{{#tag}}
+                /{{{yavd valueD}}}/, /{{{yd firstName41}}}/, /{{{yd lastName42}}}/, /{{{yd placeholderD}}}/,
+                // {{{#unless}}
+                /{{{yavd valueE}}}/, /{{{yd firstName51}}}/, /{{{yd lastName52}}}/, /{{{yd placeholderE}}}/,
+            ];
+            utils.testArrMatch(data, arr);
         });
 
         it("Template 020 - {{^msg}} statement test with correct filter", function() {
             var file = "./tests/samples/files/handlebarsjs_template_020.hbs.precompiled";
             var data = fs.readFileSync(file, 'utf-8');
-            expect(data).to.match(/{{{yavd nomsg}}}/);
-            expect(data).to.match(/{{{yd name}}}/);
-            expect(data).to.match(/{{\^msg}}/);
-            expect(data).to.match(/{{\/msg}}/);
+            var arr = [
+                /{{{yavd nomsg}}}/,
+                /{{{yd name}}}/,
+                /{{\^msg}}/,
+                /{{\/msg}}/
+            ];
+            utils.testArrMatch(data, arr);
         });
 
     });

--- a/tests/unit/run-utils-spec.js
+++ b/tests/unit/run-utils-spec.js
@@ -382,6 +382,146 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(n1).not.to.equal(n2);
         });
 
+        /* 
+        * this test is the same as "handlebars {{expression}} test" and "handlebars invalid {{expression}} test"
+        */
+        it("handlebars-utils#isValidExpression escapeExpressionRegExp test", function() {
+            var s = "{{anything}}";
+            var r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r[0]).to.equal('{{anything}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{    anything   }}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r[0]).to.equal('{{    anything   }}');
+            expect(r.result).to.equal(true);
+
+            s = "{{any\rthing}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r[0]).to.equal('{{any\rthing}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{anything}}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{anything}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{ {anything}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{anything} }";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{    {anything}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{    }anything}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+        });
+
+        /* 
+        * this test is the same as "handlebars {{{expression}}} test" and "handlebars invalid {{{expression}}} test"
+        */
+        it("handlebars-utils#isValidExpression rawExpressionRegExp test", function() {
+            s = "{{{anything}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r[0]).to.equal('{{{anything}}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{{    anything   }}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r[0]).to.equal('{{{    anything   }}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{{any\nthing}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r[0]).to.equal('{{{any\nthing}}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{{anything}}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{anything}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{ {{anything}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{anything}} }";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{anything} }}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{    {anything}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{    }anything}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+        });
+
+        it("handlebars-utils#isValidExpression greedy match test", function() {
+            var s = "{{anything}}{{anything}}";
+            var r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r[0]).to.equal('{{anything}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{    anything   }}{{    anything   }}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r[0]).to.equal('{{    anything   }}');
+            expect(r.result).to.equal(true);
+
+            s = "{{any\rthing}}{{any\rthing}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r[0]).to.equal('{{any\rthing}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{anything}}}{{anything}}}";
+            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
+            expect(r.result).to.equal(false);
+
+            s = "{{{anything}}}{{{anything}}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r[0]).to.equal('{{{anything}}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{{    anything   }}}{{{    anything   }}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r[0]).to.equal('{{{    anything   }}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{{any\nthing}}}{{{any\nthing}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r[0]).to.equal('{{{any\nthing}}}');
+            expect(r.result).to.equal(true);
+
+            s = "{{{anything}}}}{{{anything}}}}";
+            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
+            expect(r.result).to.equal(false);
+        });
+
         it("handlebars-utils#isReservedChar test", function() {
             var s = "#";
             var r = util.isReservedChar(s);
@@ -403,196 +543,196 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r).to.equal(true);
         });
 
-        it("handlebars-utils#isBranchTag (if) test", function() {
+        it("handlebars-utils#isBranchExpression (if) test", function() {
             var s = "{{#if xxx}}";
-            var r = util.isBranchTag(s);
+            var r = util.isBranchExpression(s);
             expect(r).to.equal('if');
             s = "{{#   if   xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('if');
             s = "{{/if}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('if');
             s = "{{/   if   }}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('if');
         });
 
-        it("handlebars-utils#isBranchTag (with) test", function() {
+        it("handlebars-utils#isBranchExpression (with) test", function() {
             var s = "{{#with xxx}}";
-            var r = util.isBranchTag(s);
+            var r = util.isBranchExpression(s);
             expect(r).to.equal('with');
             s = "{{#   with   xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('with');
             s = "{{/with}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('with');
             s = "{{/   with   }}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('with');
         });
 
-        it("handlebars-utils#isBranchTag (each) test", function() {
+        it("handlebars-utils#isBranchExpression (each) test", function() {
             var s = "{{#each xxx}}";
-            var r = util.isBranchTag(s);
+            var r = util.isBranchExpression(s);
             expect(r).to.equal('each');
             s = "{{#   each   xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('each');
             s = "{{/each}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('each');
             s = "{{/   each   }}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('each');
         });
 
-        it("handlebars-utils#isBranchTag (list) test", function() {
+        it("handlebars-utils#isBranchExpression (list) test", function() {
             var s = "{{#list xxx}}";
-            var r = util.isBranchTag(s);
+            var r = util.isBranchExpression(s);
             expect(r).to.equal('list');
             s = "{{#   list   xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('list');
             s = "{{/list}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('list');
             s = "{{/   list   }}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('list');
         });
 
-        it("handlebars-utils#isBranchTag (anything) test", function() {
+        it("handlebars-utils#isBranchExpression (anything) test", function() {
             s = "{{tag}}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal(false);
 
             s = "{{#tag}}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal("tag");
             s = "{{#   tag}}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal("tag");
             s = "{{#   tag   }}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal("tag");
             s = "{{#   tag   xxx}}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal("tag");
             s = "{{#   tag   xxx   }}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal("tag");
 
             s = "{{/tag}}xxx";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal("tag");
             s = "{{/   tag}}xxx";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal("tag");
             s = "{{/   tag   }}xxx";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal("tag");
         });
 
-        it("handlebars-utils#isBranchTag (negation ^msg) test", function() {
+        it("handlebars-utils#isBranchExpression (negation ^msg) test", function() {
             var s = "{{^msg}}";
-            var r = util.isBranchTag(s);
+            var r = util.isBranchExpression(s);
             expect(r).to.equal('msg');
             s = "{{^   msg    }}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('msg');
             s = "{{/msg}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('msg');
             s = "{{/   msg    }}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('msg');
         });
 
-        it("handlebars-utils#isBranchTag (illegal tag format) test", function() {
+        it("handlebars-utils#isBranchExpression (illegal tag format) test", function() {
             s = "{{#   t-ag   xxx}}xxx";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal("t-ag");
             s = "{{/   t-ag   }}xxx";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal("t-ag");
         });
 
-        it("handlebars-utils#isBranchTag (unless) test", function() {
+        it("handlebars-utils#isBranchExpression (unless) test", function() {
             var s = "{{#unless xxx}}";
-            var r = util.isBranchTag(s);
+            var r = util.isBranchExpression(s);
             expect(r).to.equal('unless');
             s = "{{#unless xxx}}{{#unless xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('unless');
             s = "{{#unless xxx}} xxx {{#unless xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('unless');
             s = "{{#   unless xxx}}";
-            r = util.isBranchTag(s);
+            r = util.isBranchExpression(s);
             expect(r).to.equal('unless');
 
             s = "{{/unless}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('unless');
             s = "{{/unless}}{{/unless}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('unless');
             s = "{{/unless}} xxx {{/unless}}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('unless');
             s = "{{/   unless   }}";
-            r = util.isBranchEndTag(s);
+            r = util.isBranchEndExpression(s);
             expect(r).to.equal('unless');
         });
 
-        it("handlebars-utils#isElseTag test", function() {
+        it("handlebars-utils#isElseExpression test", function() {
             var s = "{{else}}";
-            var r = util.isElseTag(s);
+            var r = util.isElseExpression(s);
             expect(r).to.equal(true);
             s = "{{   else   }}";
-            r = util.isElseTag(s);
+            r = util.isElseExpression(s);
             expect(r).to.equal(true);
             s = "{{else}}{{else}}";
-            r = util.isElseTag(s);
+            r = util.isElseExpression(s);
             expect(r).to.equal(true);
             s = "{{else}} xxxx {{else}}";
-            r = util.isElseTag(s);
+            r = util.isElseExpression(s);
             expect(r).to.equal(true);
         });
 
-        it("handlebars-utils#isBranchTags test", function() {
+        it("handlebars-utils#isBranchExpressions test", function() {
             var s = "{{#if xxx}}";
-            var r = util.isBranchTags(s);
+            var r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{#with}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{#each}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{#list}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{#tag}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{^msg}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{#unless}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(true);
 
             s = "{{else}}";
-            r = util.isBranchTags(s);
+            r = util.isBranchExpressions(s);
             expect(r).to.equal(false);
         });
 

--- a/tests/unit/run-utils-spec.js
+++ b/tests/unit/run-utils-spec.js
@@ -9,893 +9,556 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 */
 (function () {
 
-    var mocha = require("mocha"),
-        fs = require('fs'),
-        expect = require('expect.js'),
-        util = require("../../src/handlebars-utils.js");
+    require("mocha");
+    var expect = require('chai').expect,
+        utils = require("../utils.js"),
+        handlebarsUtils = require("../../src/handlebars-utils.js"),
+        ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
 
-    describe("handlebars-utils test suite", function() {
+    describe("handlebars-handlebarsUtilss test suite", function() {
 
-        it("handlebars-utils#_getExpressionExtraInfo {{else}} test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{else}}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{else   }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{   else   }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo output markup test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{y}}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{h}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{people.name}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{../name}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{article/title}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{article[0]}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{articles.[10].[#comments]}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{y   }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{   y   }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{y output}}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{h output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('h');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{people.name output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('people.name');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{../name output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('../name');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y   output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{h   output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('h');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{    y   output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{    h   output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('h');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y ../output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y    ../output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{    y    ../output}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo 2 arguments test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{y xxx zzz}}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y    xxx    zzz}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{    y    xxx    zzz}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo 2 arguments (reference format) test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{y xxx.name zzz}}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y ../xxx.name zzz}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{   y    xxx.name    zzz}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{   y    ../xxx.name    zzz}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo reserved tag test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{#y }}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{#    y    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo subexpression test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            /* not a valid handlebars syntax
-            str = '{y(output)}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-            */
-
-            str = '{y (output)}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y    ( output    )}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y (helper xxx)}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y    (   helper    xxx    )}}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{y (helper 'xxx')}}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{y    (   helper   'xxx'   )}}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{y helper2 (    helper1    'xxx'    )}}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{y (outer-helper (inner-helper 'abc') 'def')}}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{y     (    outer-helper (inner-helper 'abc') 'def')}}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#_getExpressionExtraInfo greedy match test", function() {
-            var ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
-            var parser = new ContextParserHandlebars();
-
-            var str = '{else    }}{{h    zzz    }}';
-            var r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y}}xxxxx{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{y}}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{y    }}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(true);
-
-            str = '{y    xxx    }}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y    ../xxx    }}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{y    xxx.name    }}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{#y    }}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(false);
-            expect(r.filter).to.equal('');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = '{   y   (   helper   xxx   )}}{{h    zzz    }}';
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{   y   (   helper   'xxx'  )}}{{h    zzz    }}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-
-            str = "{   y   helper2    (   helper1   xxx  )}}{{h    zzz    }}";
-            r = parser._getExpressionExtraInfo(str, 0);
-            expect(r.isKnownFilter).to.equal(true);
-            expect(r.filter).to.equal('y');
-            expect(r.isSingleIdentifier).to.equal(false);
-        });
-
-        it("handlebars-utils#generateNonce test", function() {
-            var n1 = util.generateNonce();
-            var n2 = util.generateNonce();
+        it("handlebars-handlebarsUtilss#generateNonce test", function() {
+            var n1 = handlebarsUtils.generateNonce();
+            var n2 = handlebarsUtils.generateNonce();
             expect(n1).not.to.equal(n2);
         });
 
-        /* 
-        * this test is the same as "handlebars {{expression}} test" and "handlebars invalid {{expression}} test"
-        */
-        it("handlebars-utils#isValidExpression escapeExpressionRegExp test", function() {
-            var s = "{{anything}}";
-            var r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r[0]).to.equal('{{anything}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{    anything   }}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r[0]).to.equal('{{    anything   }}');
-            expect(r.result).to.equal(true);
-
-            s = "{{any\rthing}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r[0]).to.equal('{{any\rthing}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{anything}}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{anything}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{ {anything}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{anything} }";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{    {anything}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{    }anything}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
+        it("handlebars-handlebarsUtilss#_parseExpression invalid format test", function() {
         });
 
-        /* 
-        * this test is the same as "handlebars {{{expression}}} test" and "handlebars invalid {{{expression}}} test"
-        */
-        it("handlebars-utils#isValidExpression rawExpressionRegExp test", function() {
-            s = "{{{anything}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r[0]).to.equal('{{{anything}}}');
-            expect(r.result).to.equal(true);
+        it("handlebars-handlebarsUtilss#_parseExpression {{else}} test", function() {
+            var parser = new ContextParserHandlebars();
 
-            s = "{{{    anything   }}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r[0]).to.equal('{{{    anything   }}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{{any\nthing}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r[0]).to.equal('{{{any\nthing}}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{{anything}}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{anything}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{ {{anything}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{anything}} }";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{anything} }}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{    {anything}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{    }anything}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
+            var arr = [
+                // test for {{else}}
+                {str:'{else}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
+                // test for {{else}} with space after else 
+                {str:'{else   }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
+                // test for {{else}} with space before/after else
+                {str:'{    else   }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
+                // test for {{else}} with space before/after else
+                // {str:'{{else}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isValidExpression greedy match test", function() {
-            var s = "{{anything}}{{anything}}";
-            var r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r[0]).to.equal('{{anything}}');
-            expect(r.result).to.equal(true);
+        it("handlebars-handlebarsUtilss#_parseExpression basic test", function() {
+            var parser = new ContextParserHandlebars();
 
-            s = "{{    anything   }}{{    anything   }}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r[0]).to.equal('{{    anything   }}');
-            expect(r.result).to.equal(true);
+            var arr = [
+                // test for single identifier with the same name as known filter {y}}
+                {str:'{y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                {str:'{y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                {str:'{    y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
 
-            s = "{{any\rthing}}{{any\rthing}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r[0]).to.equal('{{any\rthing}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{anything}}}{{anything}}}";
-            r = util.isValidExpression(s, 0, util.ESCAPE_EXPRESSION);
-            expect(r.result).to.equal(false);
-
-            s = "{{{anything}}}{{{anything}}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r[0]).to.equal('{{{anything}}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{{    anything   }}}{{{    anything   }}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r[0]).to.equal('{{{    anything   }}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{{any\nthing}}}{{{any\nthing}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r[0]).to.equal('{{{any\nthing}}}');
-            expect(r.result).to.equal(true);
-
-            s = "{{{anything}}}}{{{anything}}}}";
-            r = util.isValidExpression(s, 0, util.RAW_EXPRESSION);
-            expect(r.result).to.equal(false);
+                // test for single identifier with the same name as known default filter {h}}
+                {str:'{h}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                // test for single identifier with dot notation
+                {str:'{people.name}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                // test for single identifier with ../
+                {str:'{../name}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                // test for single identifier with /
+                {str:'{article/name}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                // test for single identifier with []
+                {str:'{article[0]}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                // test for single identifier with []
+                {str:'{article.[0].[#comments]}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                // test for expression with \r and \n as separator
+                {str:'{y\rparam}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y\nparam}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y\r\nparam}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isReservedChar test", function() {
-            var s = "#";
-            var r = util.isReservedChar(s);
-            expect(r).to.equal(true);
-            s = "/";
-            r = util.isReservedChar(s);
-            expect(r).to.equal(true);
-            s = ">";
-            r = util.isReservedChar(s);
-            expect(r).to.equal(true);
-            s = "@";
-            r = util.isReservedChar(s);
-            expect(r).to.equal(true);
-            s = "^";
-            r = util.isReservedChar(s);
-            expect(r).to.equal(true);
-            s = "!";
-            r = util.isReservedChar(s);
-            expect(r).to.equal(true);
+        it("handlebars-handlebarsUtilss#_parseExpression test", function() {
+            var parser = new ContextParserHandlebars();
+
+            var arr = [
+                // test for expression with the same name as known filter {y}}
+                {str:'{y output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y    output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{     y    output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                // test for expression with the same name as default filter {h}}
+                {str:'{h output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
+                {str:'{h    output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
+                {str:'{    h    output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
+
+                // test for expression with dot notation filter
+                {str:'{people.name output}}', isPrefixWithKnownFilter:false, filter:'people.name', isSingleIdentifier:false},
+                // test for expression with ../ filter
+                {str:'{../name output}}', isPrefixWithKnownFilter:false, filter:'../name', isSingleIdentifier:false},
+
+                // test for expression with the same name as known filter {y}} and parameter in dot notation
+                {str:'{y people.name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+		{str:'{y    people.name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{     y    people.name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+
+                // test for expression with the same name as known filter {y}} and parameter with ../
+                {str:'{y ../output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+		{str:'{y    ../output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{     y    ../output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (if) test", function() {
-            var s = "{{#if xxx}}";
-            var r = util.isBranchExpression(s);
-            expect(r).to.equal('if');
-            s = "{{#   if   xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('if');
-            s = "{{/if}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('if');
-            s = "{{/   if   }}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('if');
+        it("handlebars-handlebarsUtilss#_parseExpression 2 arguments test", function() {
+            var parser = new ContextParserHandlebars();
+
+            var arr = [
+                // test for expression with the same name as known filter {y}}
+                {str:'{y xxx zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y   xxx   zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{   y    xxx    zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+
+                // test for expression with the same name as unknown filter
+                {str:'{unknown xxx zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
+                {str:'{unknown xxx   zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
+                {str:'{   unknown    xxx    zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (with) test", function() {
-            var s = "{{#with xxx}}";
-            var r = util.isBranchExpression(s);
-            expect(r).to.equal('with');
-            s = "{{#   with   xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('with');
-            s = "{{/with}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('with');
-            s = "{{/   with   }}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('with');
+        it("handlebars-handlebarsUtilss#_parseExpression 2 arguments (reference format) test", function() {
+            var parser = new ContextParserHandlebars();
+
+            var arr = [
+                // test for expression with the same name as known filter {y}} with different parameter format
+                {str:'{y people.name ../name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y article[0] article/name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y article.[0].[#comments] article/name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+
+                // test for expression with the same name as known filter {unknown}} with different parameter format
+                {str:'{unknown people.name ../name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
+                {str:'{unknown article[0] article/name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
+                {str:'{unknown article.[0].[#comments] article/name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (each) test", function() {
-            var s = "{{#each xxx}}";
-            var r = util.isBranchExpression(s);
-            expect(r).to.equal('each');
-            s = "{{#   each   xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('each');
-            s = "{{/each}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('each');
-            s = "{{/   each   }}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('each');
+        it("handlebars-handlebarsUtilss#_parseExpression reserved tag test", function() {
+            var parser = new ContextParserHandlebars();
+
+            var arr = [
+                // test for reserved expression {{#.*}}
+                {str:'{#y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                {str:'{#   y   xxx}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                // test for reserved expression {{/.*}}
+                {str:'{/y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                {str:'{/   y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                // test for reserved expression {{>.*}}
+                {str:'{>partial}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                {str:'{>   partial    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                // test for reserved expression {{^.*}}
+                {str:'{^negation}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                {str:'{^   negation   }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                // test for reserved expression {{!.*}}
+                {str:'{!comment}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                {str:'{!   comment    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                // test for reserved expression {{@.*}}
+                {str:'{@var}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
+                {str:'{@   var   }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (list) test", function() {
-            var s = "{{#list xxx}}";
-            var r = util.isBranchExpression(s);
-            expect(r).to.equal('list');
-            s = "{{#   list   xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('list');
-            s = "{{/list}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('list');
-            s = "{{/   list   }}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('list');
+        it("handlebars-handlebarsUtilss#_parseExpression subexpression test", function() {
+            var parser = new ContextParserHandlebars();
+
+            var arr = [
+                // not a valid handlebars syntax, no need to test
+                // {str:'{y(output)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                // subexpression with one chain
+                {str:'{y (output)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y    (   output   )    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                // subexpression with two chain
+                {str:'{y (helper xxx)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y    (   helper    xxx   )   }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y (helper "xxx")}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y    (   helper    "xxx"   )   }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                // subexpression with three chain
+                {str:'{y helper2 (helper1 xxx)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y    helper2    (   helper1    xxx   )}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                {str:'{y    helper2    (   helper1    "xxx"   )}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                //
+                {str:'{y     (    outer-helper (inner-helper "abc") "def")}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (anything) test", function() {
-            s = "{{tag}}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal(false);
+        it("handlebars-handlebarsUtilss#_parseExpression greedy match test", function() {
+            var parser = new ContextParserHandlebars();
 
-            s = "{{#tag}}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal("tag");
-            s = "{{#   tag}}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal("tag");
-            s = "{{#   tag   }}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal("tag");
-            s = "{{#   tag   xxx}}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal("tag");
-            s = "{{#   tag   xxx   }}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal("tag");
-
-            s = "{{/tag}}xxx";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal("tag");
-            s = "{{/   tag}}xxx";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal("tag");
-            s = "{{/   tag   }}xxx";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal("tag");
+            var arr = [
+                // immediate after an expression
+                {str:'{else}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
+                {str:'{y}}{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                {str:'{y param}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
+                // not immediate after an expression
+                {str:'{else}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
+                {str:'{y}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
+                {str:'{y param}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = parser._parseExpression(obj.str, 0);
+                utils.testExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (negation ^msg) test", function() {
-            var s = "{{^msg}}";
-            var r = util.isBranchExpression(s);
-            expect(r).to.equal('msg');
-            s = "{{^   msg    }}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('msg');
-            s = "{{/msg}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('msg');
-            s = "{{/   msg    }}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('msg');
+        it("handlebars-handlebarsUtilss#isValidExpression escapeExpressionRegExp test", function() {
+            var arr = [
+                // basic
+                {str:'{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{anything}}'},
+                {str:'{{   anything   }}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{   anything   }}'},
+                // with \r and \n
+                {str:'{{any\rthing}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\rthing}}'},
+                {str:'{{any\nthing}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\nthing}}'},
+                {str:'{{any\r\nthing}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\r\nthing}}'},
+
+                // invalid expression
+                {str:'{ {anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{anything}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{anything} }', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{anything}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{    {anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{    }anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
+                utils.testIsValidExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (illegal tag format) test", function() {
-            s = "{{#   t-ag   xxx}}xxx";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal("t-ag");
-            s = "{{/   t-ag   }}xxx";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal("t-ag");
+        it("handlebars-handlebarsUtilss#isValidExpression rawExpressionRegExp test", function() {
+            var arr = [
+                // basic
+                {str:'{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{anything}}}'},
+                {str:'{{{   anything   }}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{   anything   }}}'},
+                // with \r and \n
+                {str:'{{{any\rthing}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\rthing}}}'},
+                {str:'{{{any\nthing}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\nthing}}}'},
+                {str:'{{{any\r\nthing}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\r\nthing}}}'},
+
+                // invalid expression
+                {str:'{ {{anything}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{ {anything}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{{anything}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{{anything}}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{{   {anything}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{{   }anything}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
+                {str:'{{{}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false}
+            ];
+            arr.forEach(function(obj) {
+                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
+                utils.testIsValidExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isBranchExpression (unless) test", function() {
-            var s = "{{#unless xxx}}";
-            var r = util.isBranchExpression(s);
-            expect(r).to.equal('unless');
-            s = "{{#unless xxx}}{{#unless xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('unless');
-            s = "{{#unless xxx}} xxx {{#unless xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('unless');
-            s = "{{#   unless xxx}}";
-            r = util.isBranchExpression(s);
-            expect(r).to.equal('unless');
+        it("handlebars-handlebarsUtilss#isValidExpression greedy match test", function() {
+            var arr = [
+                // basic
+                {str:'{{anything}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{anything}}'},
+                {str:'{{   anything   }}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{   anything   }}'},
+                {str:'{{anything}}xxx{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{anything}}'},
+                {str:'{{   anything   }}xxx{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{   anything   }}'},
 
-            s = "{{/unless}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('unless');
-            s = "{{/unless}}{{/unless}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('unless');
-            s = "{{/unless}} xxx {{/unless}}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('unless');
-            s = "{{/   unless   }}";
-            r = util.isBranchEndExpression(s);
-            expect(r).to.equal('unless');
+                // with \r and \n
+                {str:'{{any\rthing}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\rthing}}'},
+                {str:'{{any\nthing}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\nthing}}'},
+                {str:'{{any\r\nthing}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\r\nthing}}'},
+
+                // basic
+                {str:'{{{anything}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{anything}}}'},
+                {str:'{{{   anything   }}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{   anything   }}}'},
+                {str:'{{{anything}}}xxx{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{anything}}}'},
+                {str:'{{{   anything   }}}xxx{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{   anything   }}}'},
+
+                // with \r and \n
+                {str:'{{{any\rthing}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\rthing}}}'},
+                {str:'{{{any\nthing}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\nthing}}}'},
+                {str:'{{{any\r\nthing}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\r\nthing}}}'},
+            ];
+            arr.forEach(function(obj) {
+                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
+                utils.testIsValidExpression(r, obj); 
+            });
         });
 
-        it("handlebars-utils#isElseExpression test", function() {
-            var s = "{{else}}";
-            var r = util.isElseExpression(s);
-            expect(r).to.equal(true);
-            s = "{{   else   }}";
-            r = util.isElseExpression(s);
-            expect(r).to.equal(true);
-            s = "{{else}}{{else}}";
-            r = util.isElseExpression(s);
-            expect(r).to.equal(true);
-            s = "{{else}} xxxx {{else}}";
-            r = util.isElseExpression(s);
-            expect(r).to.equal(true);
+        it("handlebars-handlebarsUtilss#isReservedChar test", function() {
+            [
+                '#', '/', '>', '@', '^', '!'
+            ].forEach(function(c) {
+                var r = handlebarsUtils.isReservedChar(c);
+                expect(r).to.equal(true);
+            });
         });
 
-        it("handlebars-utils#isBranchExpressions test", function() {
-            var s = "{{#if xxx}}";
-            var r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
+        it("handlebars-handlebarsUtilss#isBranchExpression test", function() {
+            [
+                {str: '{{#if xxx}}', rstr: 'if'},
+                {str: '{{#if xxx}}{{#if xxx}}', rstr: 'if'},
+                {str: '{{#if xxx}}x{{#if xxx}}', rstr: 'if'},
+                {str: '{{#if xxx}} x {{#if xxx}}', rstr: 'if'},
+                {str: '{{#   if   xxx}}', rstr: 'if'},
 
-            s = "{{#with}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
+                {str: '{{#with xxx}}', rstr: 'with'},
+                {str: '{{#each xxx}}', rstr: 'each'},
+                {str: '{{#list xxx}}', rstr: 'list'},
+                {str: '{{#unless xxx}}', rstr: 'unless'},
+                {str: '{{#tag xxx}}', rstr: 'tag'},
+                {str: '{{^msg xxx}}', rstr: 'msg'},
 
-            s = "{{#each}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
-
-            s = "{{#list}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
-
-            s = "{{#tag}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
-
-            s = "{{^msg}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
-
-            s = "{{#unless}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(true);
-
-            s = "{{else}}";
-            r = util.isBranchExpressions(s);
-            expect(r).to.equal(false);
+                // illegal handlebars format
+                {str: '{{#t-ag xxx}}', rstr: 't-ag'}
+            ].forEach(function(obj) {
+                var r = handlebarsUtils.isBranchExpression(obj.str);
+                expect(r).to.equal(obj.rstr);
+            });
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#if xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss#isBranchEndExpression test", function() {
+            [
+                {str: '{{/if}}', rstr: 'if'},
+                {str: '{{/if}}{{/if}}', rstr: 'if'},
+                {str: '{{/if}}x{{/if}}', rstr: 'if'},
+                {str: '{{/if}} x {{/if}}', rstr: 'if'},
+                {str: '{{/   if   }}', rstr: 'if'},
+
+                {str: '{{/with}}', rstr: 'with'},
+                {str: '{{/each}}', rstr: 'each'},
+                {str: '{{/list}}', rstr: 'list'},
+                {str: '{{/unless}}', rstr: 'unless'},
+                {str: '{{/tag}}', rstr: 'tag'},
+                {str: '{{/msg}}', rstr: 'msg'},
+
+                // illegal handlebars format
+                {str: '{{/t-ag}}', rstr: 't-ag'}
+            ].forEach(function(obj) {
+                var r = handlebarsUtils.isBranchEndExpression(obj.str);
+                expect(r).to.equal(obj.rstr);
+            });
+        });
+
+        it("handlebars-handlebarsUtilss#isElseExpression test", function() {
+            [
+                {str: '{{else}}', result:true},
+                {str: '{{   else   }}', result:true},
+                {str: '{{else}}{{else}}', result:true},
+                {str: '{{else}}x{{else}}', result:true},
+                {str: '{{else}} x {{else}}', result:true}
+            ].forEach(function(obj) {
+                var r = handlebarsUtils.isElseExpression(obj.str);
+                expect(r).to.equal(obj.result);
+            });
+        });
+
+        it("handlebars-handlebarsUtilss#isBranchExpressions test", function() {
+            [
+                {str: '{{#if xxx}}', result:true},
+                {str: '{{#if xxx}}{{#if xxx}}', result:true},
+                {str: '{{#if xxx}}x{{#if xxx}}', result:true},
+                {str: '{{#if xxx}} x {{#if xxx}}', result:true},
+
+                {str: '{{#with xxx}}', result:true},
+                {str: '{{#each xxx}}', result:true},
+                {str: '{{#list xxx}}', result:true},
+                {str: '{{#unless xxx}}', result:true},
+                {str: '{{#tag xxx}}', result:true},
+
+                {str: '{{^msg xxx}}', result:true},
+
+                {str: '{{else}}', result:false},
+                {str: '{{expression}}', result:false},
+                {str: '{{{expression}}}', result:false},
+            ].forEach(function(obj) {
+                var r = handlebarsUtils.isBranchExpressions(obj.str);
+                expect(r).to.equal(obj.result);
+            });
+        });
+
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#if xxx}} statement test", function() {
             var s = "{{#if xxx}} a {{/if}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#if xxx}} a {{\/if}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#if xxx}} statement with {{else}} test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#if xxx}} statement with {{else}} test", function() {
             var s = "{{#if xxx}} a {{else}} b {{/if}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#if xxx}} a {{else}} b {{\/if}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#if xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#if xxx}} statement test", function() {
             var s = "{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{else}} e {{#if}} f {{else}} h {{/if}} i {{/if}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{else}} e {{#if}} f {{else}} h {{/if}} i {{/if}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#with xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#with xxx}} statement test", function() {
             var s = "{{#with xxx}} a {{/with}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#with xxx}} a {{\/with}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#with xxx}} statement with {{else}} test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#with xxx}} statement with {{else}} test", function() {
             var s = "{{#with xxx}} a {{else}} b {{/with}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#with xxx}} a {{else}} b {{\/with}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#with xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#with xxx}} statement test", function() {
             var s = "{{#with xxx}} a {{#with}} b {{else}} c {{/with}} d {{else}} e {{#with}} f {{else}} h {{/with}} i {{/with}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#with xxx}} a {{#with}} b {{else}} c {{/with}} d {{else}} e {{#with}} f {{else}} h {{/with}} i {{/with}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#each xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#each xxx}} statement test", function() {
             var s = "{{#each xxx}} a {{/each}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#each xxx}} a {{\/each}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#each xxx}} statement with {{else}} test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#each xxx}} statement with {{else}} test", function() {
             var s = "{{#each xxx}} a {{else}} b {{/each}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#each xxx}} a {{else}} b {{\/each}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#each xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#each xxx}} statement test", function() {
             var s = "{{#each xxx}} a {{#each}} b {{else}} c {{/each}} d {{else}} e {{#each}} f {{else}} h {{/each}} i {{/each}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#each xxx}} a {{#each}} b {{else}} c {{/each}} d {{else}} e {{#each}} f {{else}} h {{/each}} i {{/each}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#list xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#list xxx}} statement test", function() {
             var s = "{{#list xxx}} a {{/list}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#list xxx}} a {{\/list}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#list xxx}} statement with {{else}} test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#list xxx}} statement with {{else}} test", function() {
             var s = "{{#list xxx}} a {{else}} b {{/list}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#list xxx}} a {{else}} b {{\/list}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#list xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#list xxx}} statement test", function() {
             var s = "{{#list xxx}} a {{#list yyy}} b {{else}} c {{/list}} d {{else}} e {{#list zzz}} f {{else}} h {{/list}} i {{/list}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#list xxx}} a {{#list yyy}} b {{else}} c {{/list}} d {{else}} e {{#list zzz}} f {{else}} h {{/list}} i {{/list}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#tag xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#tag xxx}} statement test", function() {
             var s = "{{#tag xxx}} a {{/tag}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#tag xxx}} a {{\/tag}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#tag xxx}} statement with {{else}} test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#tag xxx}} statement with {{else}} test", function() {
             var s = "{{#tag xxx}} a {{else}} b {{/tag}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#tag xxx}} a {{else}} b {{\/tag}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#tag xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#tag xxx}} statement test", function() {
             var s = "{{#tag xxx}} a {{#tag yyy}} b {{else}} c {{/tag}} d {{else}} e {{#tag zzz}} f {{else}} h {{/tag}} i {{/tag}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#tag xxx}} a {{#tag yyy}} b {{else}} c {{/tag}} d {{else}} e {{#tag zzz}} f {{else}} h {{/tag}} i {{/tag}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{^msg}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{^msg}} statement test", function() {
             var s = "{{^msg}} a {{/msg}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{^msg}} a {{\/msg}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{^msg}} statement with {{else}} test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{^msg}} statement with {{else}} test", function() {
             var s = "{{^msg}} a {{else}} b {{/msg}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{^msg}} a {{else}} b {{\/msg}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{^msg}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{^msg}} statement test", function() {
             var s = "{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{else}} e {{^msg}} f {{else}} h {{/msg}} i {{/msg}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{else}} e {{^msg}} f {{else}} h {{/msg}} i {{/msg}}');
         });
 
-        it("handlebars-utils - extract basic Handlebars {{#unless xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract basic Handlebars {{#unless xxx}} statement test", function() {
             var s = "{{#unless xxx}} a {{/unless}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#unless xxx}} a {{\/unless}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#unless xxx}} statement test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#unless xxx}} statement test", function() {
             var s = "{{#unless xxx}} a {{#unless xxx}} b {{/unless}} c {{/unless}} zzzzzzzz";
-            var r = util.extractBranchStmt(s, 0, false);
+            var r = handlebarsUtils.extractBranchStmt(s, 0, false);
             expect(r['stmt']).to.equal('{{#unless xxx}} a {{#unless xxx}} b {{/unless}} c {{/unless}}');
         });
 
-        it("handlebars-utils - extract nested Handlebars {{#unless xxx}} statement exception test", function() {
+        it("handlebars-handlebarsUtilss - extract nested Handlebars {{#unless xxx}} statement exception test", function() {
             var s = "{{#if} aaaaaaaa";
             try {
-                var r = util.extractBranchStmt(s, 0, false);
+                var r = handlebarsUtils.extractBranchStmt(s, 0, false);
                 expect(false).to.equal(true);
             } catch (err) {
                 expect(true).to.equal(true);
             }
         });
 
-        it("handlebars-utils - parse basic Handlebars {{#if xxx}} statement parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse basic Handlebars {{#if xxx}} statement parseAstTreeState test", function() {
             var s = "<a href='{{#if xxx}} a {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{#if xxx}} a {{/if}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a (1st branch)
             // 'empty string' (2nd branch)
             expect(r.lastStates[0]).to.equal(39);
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse basic Handlebars {{#if xxx}} statement with {{else}} parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse basic Handlebars {{#if xxx}} statement with {{else}} parseAstTreeState test", function() {
             var s = "<a href='{{#if xxx}} a {{else}} b {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{#if xxx}} a {{else}} b {{/if}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a (1st branch)
             // b (2nd branch)
             expect(r.lastStates[0]).to.equal(39);
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse nested Handlebars {{#if xxx}} statement parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse nested Handlebars {{#if xxx}} statement parseAstTreeState test", function() {
             var s = "<a href='{{#if xxx}} a {{#if}} b {{/if}} c {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{#if xxx}} a {{#if}} b {{/if}} c {{/if}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  c (1st branch)
             // a  c (1st branch)
             // 'empty string' (2nd branch)
@@ -903,12 +566,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse nested Handlebars {{#if xxx}} statement with {{else}} parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse nested Handlebars {{#if xxx}} statement with {{else}} parseAstTreeState test", function() {
             var s = "<a href='{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{else}} e {{#if}} f {{else}} g {{/if}} h {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{else}} e {{#if}} f {{else}} g {{/if}} h {{/if}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  d (1st branch)
             // a  c  d (1st branch)
             // e  f  h (2nd branch)
@@ -917,12 +580,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse parallel Handlebars {{#if xxx}} statement parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse parallel Handlebars {{#if xxx}} statement parseAstTreeState test", function() {
             var s = "<a href='{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{#if}} b {{else}} c {{/if}} f {{else}} e {{#if xyz}} f {{else}} g {{/if}} h {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{#if}} b {{else}} c {{/if}} f {{else}} e {{#if xyz}} f {{else}} g {{/if}} h {{/if}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  d  b  f (1st branch)
             // a  c  d  b  f (1st branch)
             // a  b  d  c  f (1st branch)
@@ -933,12 +596,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse parallel Handlebars {{#if}} statement with {{else}} parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse parallel Handlebars {{#if}} statement with {{else}} parseAstTreeState test", function() {
             var s = "<a href='{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{#if}} b {{else}} c {{/if}} f {{else}} e {{#if}} f {{else}} g {{/if}} h {{#if}} 1 {{else}} 2 {{/if}} h {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{#if xxx}} a {{#if}} b {{else}} c {{/if}} d {{#if}} b {{else}} c {{/if}} f {{else}} e {{#if}} f {{else}} g {{/if}} h {{#if}} 1 {{else}} 2 {{/if}} h {{/if}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  d  b  f (1st branch)
             // a  c  d  b  f (1st branch)
             // a  b  d  c  f (1st branch)
@@ -951,36 +614,36 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse basic Handlebars {{^msg}} statement parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse basic Handlebars {{^msg}} statement parseAstTreeState test", function() {
             var s = "<a href='{{^msg}} a {{/msg}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{^msg}} a {{/msg}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a (1st branch)
             // b (2nd branch)
             expect(r.lastStates[0]).to.equal(39);
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse basic Handlebars {{^msg}} statement with {{else}} parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse basic Handlebars {{^msg}} statement with {{else}} parseAstTreeState test", function() {
             var s = "<a href='{{^msg}} a {{else}} b {{/msg}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{^msg}} a {{else}} b {{/msg}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a (1st branch)
             // b (2nd branch)
             expect(r.lastStates[0]).to.equal(39);
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse nested Handlebars {{^msg}} statement parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse nested Handlebars {{^msg}} statement parseAstTreeState test", function() {
             var s = "<a href='{{^msg}} a {{^msg}} b {{/msg}} c {{/msg}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{^msg}} a {{^msg}} b {{/msg}} c {{/msg}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  c (1st branch)
             // a  c (1st branch)
             // 'empty string' (2nd branch)
@@ -988,12 +651,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse nested Handlebars {{^msg}} statement with {{else}} parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse nested Handlebars {{^msg}} statement with {{else}} parseAstTreeState test", function() {
             var s = "<a href='{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{else}} e {{^msg}} f {{else}} g {{/msg}} h {{/msg}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{else}} e {{^msg}} f {{else}} g {{/msg}} h {{/msg}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  d (1st branch)
             // a  c  d (1st branch)
             // e  f  h (2nd branch)
@@ -1002,12 +665,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse parallel Handlebars {{^msg}} statement parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse parallel Handlebars {{^msg}} statement parseAstTreeState test", function() {
             var s = "<a href='{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{^msg}} b {{else}} c {{/msg}} f {{else}} e {{^msg}} f {{else}} g {{/msg}} h {{/msg}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{^msg}} b {{else}} c {{/msg}} f {{else}} e {{^msg}} f {{else}} g {{/msg}} h {{/msg}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  d  b  f (1st branch)
             // a  c  d  b  f (1st branch)
             // a  b  d  c  f (1st branch)
@@ -1018,12 +681,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse parallel Handlebars {{^msg}} statement with {{else}} parseAstTreeState test", function() {
+        it("handlebars-handlebarsUtilss - parse parallel Handlebars {{^msg}} statement with {{else}} parseAstTreeState test", function() {
             var s = "<a href='{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{^msg}} b {{else}} c {{/msg}} f {{else}} e {{^msg}} f {{else}} g {{/msg}} h {{^msg}} 1 {{else}} 2 {{/msg}} h {{/msg}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
             expect(obj.stmt).to.equal('{{^msg}} a {{^msg}} b {{else}} c {{/msg}} d {{^msg}} b {{else}} c {{/msg}} f {{else}} e {{^msg}} f {{else}} g {{/msg}} h {{^msg}} 1 {{else}} 2 {{/msg}} h {{/msg}}');
-            var ast = util.parseBranchStmt(obj.stmt);
-            var r = util.parseAstTreeState(ast, 39, obj);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
+            var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
             // a  b  d  b  f (1st branch)
             // a  c  d  b  f (1st branch)
             // a  b  d  c  f (1st branch)
@@ -1036,12 +699,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.lastStates[1]).to.equal(39);
         });
 
-        it("handlebars-utils - parse basic Handlebars {{#if xxx}} broken statement with {{else}} parseAstTreeState exception test", function() {
+        it("handlebars-handlebarsUtilss - parse basic Handlebars {{#if xxx}} broken statement with {{else}} parseAstTreeState exception test", function() {
             var s = "<a href='{{#if xxx}} a {{else}} b'> {{/if}}'>";
-            var obj = util.extractBranchStmt(s, 9, true);
-            var ast = util.parseBranchStmt(obj.stmt);
+            var obj = handlebarsUtils.extractBranchStmt(s, 9, true);
+            var ast = handlebarsUtils.parseBranchStmt(obj.stmt);
             try {
-                var r = util.parseAstTreeState(ast, 39, obj);
+                var r = handlebarsUtils.parseAstTreeState(ast, 39, obj);
                 expect(false).to.equal(true);
             } catch (err) {
                 expect(true).to.equal(true);

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2015, Yahoo! Inc. All rights reserved.
+Copyrights licensed under the New BSD License.
+See the accompanying LICENSE file for terms.
+*/
+(function() {
+
+var expect = require('chai').expect;
+
+exports.testArrMatch = function(data, arr) {
+   arr.forEach(function(p) {
+       expect(data).to.match(p);
+   });
+};
+
+exports.testExpression = function(result, obj) {
+    expect(result.isPrefixWithKnowFilter).to.equal(obj.isPrefixWithKnowFilter);
+    expect(result.filter).to.equal(obj.filter);
+    expect(result.isSingleIdentifier).to.equal(obj.isSingleIdentifier);
+};
+
+exports.testIsValidExpression = function(result, obj) {
+    if (obj.hasOwnProperty('rstr')) {
+        expect(result[0]).to.equal(obj.rstr);
+    }
+    expect(result.result).to.equal(obj.result);
+};
+
+})();


### PR DESCRIPTION
- add validation/check of handlebars expression syntax.
- add line no and char no in error message 
- enforce to use Handlebars 2.0.0 for parsing.
- using chai to replace expect.js 
- enhance the unit test with comments (refactor)