### PR TITLE
refactor and clean up the code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-parser-handlebars",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "licenses": [
     {
       "type": "BSD",
@@ -53,7 +53,7 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-mocha-istanbul": "^2.3.0",
-    "handlebars": "*"
+    "handlebars": "3.0.0"
   },
   "main": "./src/context-parser-handlebars.js",
   "bugs": {

--- a/src/context-parser-handlebars.js
+++ b/src/context-parser-handlebars.js
@@ -57,7 +57,6 @@ function ContextParserHandlebars(config) {
     this._lineNo = 1;
     this._charNo = 1;
 
-    debug("_printChar:"+config.printCharEnable);
     debug("_printChar:"+this._printCharEnable);
     debug("_strictMode:"+this._strictMode);
 }

--- a/src/handlebarspc.js
+++ b/src/handlebarspc.js
@@ -31,7 +31,9 @@ This utility parse the handlebars template file and add the customized filters
         if (fs.existsSync(file)) {
             try {
                 var data = fs.readFileSync(file, 'utf-8');
-                var parser = new ContextParserHandlebars(printChar);
+                var config = {};
+                config.printCharEnable = printChar;
+                var parser = new ContextParserHandlebars(config);
                 parser.contextualize(data);
                 parser.printCharWithState();
             } catch (err) {

--- a/tests/unit/000-run-precompiler-spec.js
+++ b/tests/unit/000-run-precompiler-spec.js
@@ -120,6 +120,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
         /* reported bug tests */
         [
+            /* remove unnecessary test
             {
                 title: '/bin/handlebarspc html5 inconsistent state test',
                 file: './tests/samples/bugs/001.hbs',
@@ -135,6 +136,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 file: './tests/samples/bugs/002.hbs',
                 result: [],
             },
+            */
             {
                 title: './bin/handlebarspc html5 inconsistent state test',
                 file: './tests/samples/bugs/004.script.hb',

--- a/tests/unit/000-run-precompiler-spec.js
+++ b/tests/unit/000-run-precompiler-spec.js
@@ -19,6 +19,9 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
     var NO_OF_TEMPLATE = 24,
         NO_OF_FILTER_TEMPLATE = 20;
 
+    var config = {};
+    config.printCharEnable = false;
+
     describe("Handlebars PreCompiler Test Suite", function() {
 
         // basic test
@@ -37,7 +40,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             it("ContextParserHandlebars#contextualize template " + id + " test", function() {
                 var file = './tests/samples/files/handlebarsjs_template_'+id+'.hbs';
                 var data = fs.readFileSync(file, 'utf-8');
-                var parser = new ContextParserHandlebars(false);
+                var parser = new ContextParserHandlebars(config);
                 try {
                     parser.contextualize(data);
                     var output = parser.getBuffer().join('');
@@ -58,7 +61,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             it("ContextParserHandlebars#contextualize filter " + id + " test", function() {
                 var file = './tests/samples/files/handlebarsjs_filter_'+id+'.hbs';
                 var data = fs.readFileSync(file, 'utf-8');
-                var parser = new ContextParserHandlebars(false);
+                var parser = new ContextParserHandlebars(config);
                 try {
                     parser.contextualize(data);
                     var output = parser.getBuffer().join('');

--- a/tests/unit/run-cph-spec.js
+++ b/tests/unit/run-cph-spec.js
@@ -15,323 +15,40 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         handlebarsUtils = require("../../src/handlebars-utils.js"),
         ContextParserHandlebars = require("../../src/context-parser-handlebars.js");
 
+    var config = {};
+    config.printCharEnable = false;
+
     describe("context-parser-handlebars test suite", function() {
 
         it("context-parser-handlebars#_countNewLineChar test", function() {
-        });
-
-        it("context-parser-handlebars#_parseExpression invalid format test", function() {
+            // no need to test it directly
         });
 
         it("context-parser-handlebars#_addFilters invalid format test", function() {
-        });
-
-        it("context-parser-handlebars#_parseExpression {{else}} test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // test for {{else}}
-                {str:'{{else}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                // test for {{else}} with space after else 
-                {str:'{{else   }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                // test for {{else}} with space before/after else
-                {str:'{{    else   }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                // invalid format
-                {str:'{else}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~else}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~else~}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~  else}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~  else  ~}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-
-                {str:'{{^}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{^    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{    ^    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~^}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~^~}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~    ^}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~    ^    ~}}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression basic test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // test for single identifier with the same name as known filter {{y}}
-                {str:'{{y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{    y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-
-                // with ~
-                {str:'{{~y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~    y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y~}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y    ~}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~    y    ~}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-
-                // test for single identifier with the same name as known default filter {{h}}
-                {str:'{{h}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                // test for single identifier with dot notation
-                {str:'{{people.name}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                // test for single identifier with ../
-                {str:'{{../name}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                // test for single identifier with /
-                {str:'{{article/name}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                // test for single identifier with []
-                {str:'{{article[0]}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                // test for single identifier with []
-                {str:'{{article.[0].[#comments]}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                // test for expression with \r and \n as separator
-                {str:'{{y\rparam}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y\nparam}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y\r\nparam}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // test for expression with the same name as known filter {{y}}
-                {str:'{{y output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y    output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{     y    output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                // test for expression with the same name as default filter {h}}
-                {str:'{{h output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
-                {str:'{{h    output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
-                {str:'{{    h    output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~y output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~y    output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~     y    output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~h output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
-                {str:'{{~h    output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
-                {str:'{{~    h    output}}', isPrefixWithKnownFilter:false, filter:'h', isSingleIdentifier:false},
-
-                // test for expression with dot notation filter
-                {str:'{{people.name output}}', isPrefixWithKnownFilter:false, filter:'people.name', isSingleIdentifier:false},
-                // test for expression with ../ filter
-                {str:'{{../name output}}', isPrefixWithKnownFilter:false, filter:'../name', isSingleIdentifier:false},
-
-                // test for expression with the same name as known filter {{y}} and parameter in dot notation
-                {str:'{{y people.name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-		{str:'{{y    people.name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{     y    people.name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // test for expression with the same name as known filter {{y}} and parameter with ../
-                {str:'{{y ../output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-		{str:'{{y    ../output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{     y    ../output}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression 2 arguments test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // test for expression with the same name as known filter {{y}}
-                {str:'{{y xxx zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y   xxx   zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{   y    xxx    zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~y xxx zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~y   xxx   zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~   y    xxx    zzz}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // test for expression with the same name as unknown filter
-                {str:'{{unknown xxx zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{unknown xxx   zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{   unknown    xxx    zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~unknown xxx zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{~unknown xxx   zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{~   unknown    xxx    zzz}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false}
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression 2 arguments (reference format) test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // test for expression with the same name as known filter {{y}} with different parameter format
-                {str:'{{y people.name ../name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y article[0] article/name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y article.[0].[#comments] article/name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~y people.name ../name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~y article[0] article/name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{~y article.[0].[#comments] article/name}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // test for expression with the same name as known filter {{unknown}} with different parameter format
-                {str:'{{unknown people.name ../name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{unknown article[0] article/name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{unknown article.[0].[#comments] article/name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-
-                {str:'{{~unknown people.name ../name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{~unknown article[0] article/name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false},
-                {str:'{{~unknown article.[0].[#comments] article/name}}', isPrefixWithKnownFilter:false, filter:'unknown', isSingleIdentifier:false}
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression reserved tag test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // test for reserved expression {{#.*}}
-                {str:'{{#y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{#   y   xxx}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // with ~
-                {str:'{{~#y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{~#   y   xxx}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // test for reserved expression {{/.*}}
-                {str:'{{/y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{/   y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // with ~
-                {str:'{{~/y}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{~/   y    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // test for reserved expression {{>.*}}
-                {str:'{{>partial}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{>   partial    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // with ~
-                {str:'{{~>partial}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{~>   partial    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // test for reserved expression {{^.*}}
-                {str:'{{^negation}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{^   negation   }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // with ~
-                {str:'{{~^negation}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{~^   negation   }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // test for reserved expression {{!.*}}
-                {str:'{{!comment}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{!   comment    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // with ~
-                {str:'{{~!comment}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{~!   comment    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // test for reserved expression {{@.*}}
-                {str:'{{@var}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{@   var   }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                // with ~
-                {str:'{{~@var}}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false},
-                {str:'{{~@   var   }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:false}
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression subexpression test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // not a valid handlebars syntax, no need to test
-                // {str:'{{y(output)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                // subexpression with one chain
-                {str:'{{y (output)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y    (   output   )    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                // subexpression with two chain
-                {str:'{{y (helper xxx)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y    (   helper    xxx   )   }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y (helper "xxx")}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y    (   helper    "xxx"   )   }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                // subexpression with three chain
-                {str:'{{y helper2 (helper1 xxx)}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y    helper2    (   helper1    xxx   )}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                {str:'{{y    helper2    (   helper1    "xxx"   )}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-                //
-                {str:'{{y     (    outer-helper (inner-helper "abc") "def")}}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false}
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_parseExpression greedy match test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                // immediate after an expression
-                {str:'{{else}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{y}}{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{y param}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~else}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~else~}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~y}}{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y~}}{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y param}}{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // not immediate after an expression
-                {str:'{{else}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{y}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{y param}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false},
-
-                // with ~
-                {str:'{{~else}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~else~}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'', isSingleIdentifier:false},
-                {str:'{{~y}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y~}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:false, filter:'', isSingleIdentifier:true},
-                {str:'{{~y param}}xxxx{{h    zzz    }}', isPrefixWithKnownFilter:true, filter:'y', isSingleIdentifier:false}
-            ].forEach(function(obj) {
-                var r = parser._parseExpression(obj.str, 0);
-                utils.testExpression(r, obj); 
-            });
-        });
-
-        it("context-parser-handlebars#_handleRawExpression test", function() {
+            // no need to test it directly
         });
 
         it("context-parser-handlebars#_handleEscapeExpression test", function() {
+            // no need to test it directly
         });
 
-        it("context-parser-handlebars#_handleCommentExpression test", function() {
-            var parser = new ContextParserHandlebars();
-            [
-                {str: '{{! comment }}', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, result:13},
-                {str: '{{! comment }} }}', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, result:13},
-                {str: '{{!-- comment --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:17},
-                {str: '{{!-- comment --}}  --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:17},
-                {str: '{{!-- comment }}  --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:21},
-
-                {str: '{{~! comment }}', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, result:14},
-                {str: '{{~! comment }} }}', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, result:14},
-                {str: '{{~!-- comment --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:18},
-                {str: '{{~!-- comment --}}  --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:18},
-                {str: '{{~!-- comment }}  --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:22},
-
-                // these cases are guarded against by isCommentExpression
-                {str: '{{!-- comment }}', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, result:15},
-                {str: '{{! comment --}}', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, result:15}
-            ].forEach(function(obj) {
-                var r = parser._handleCommentExpression(obj.str, 0, obj.str.length, obj.type, false);
-                expect(r.index).to.equal(obj.result);
+        /* handleBranchExpression test */
+        it("context-parser-handlebars#_handleBranchExpression test", function() {
+            utils.branchExpressionTestPatterns.forEach(function(testObj) {
+                try {
+                    var parser = new ContextParserHandlebars(config);
+                    var r = parser._handleBranchExpression(testObj.syntax, 0, 1);
+                    expect(testObj.result[2]).to.equal(r.index);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(r).to.equal(undefined);
+                    expect(testObj.result[2]).to.equal(false);
+                }
             });
         });
 
-        it("context-parser-handlebars#_handleExpression test", function() {
-        });
-
-        it("context-parser-handlebars#_handleBranchExpression test", function() {
-        });
-
-        it("context-parser-handlebars - basic branch AST test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#basic branch AST test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if xxx}} a b {{/if}}xxxxxxx";
             var ast = parser._buildBranchAst(s, 0);
             expect(ast.program[0].type).to.equal('branch');
@@ -348,8 +65,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.output).to.equal('{{#if xxx}} a b {{/if}}');
         });
 
-        it("context-parser-handlebars - basic branch with {{expression}} AST test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#basic branch with {{expression}} AST test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if xxx}} a b {{expression}} {{/if}}xxxxxxx";
             var ast = parser._buildBranchAst(s, 0);
             expect(ast.program[0].type).to.equal('branch');
@@ -366,8 +83,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.output).to.equal('{{#if xxx}} a b {{{yd expression}}} {{/if}}');
         });
 
-        it("context-parser-handlebars - basic branch with {{!comment}} AST test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#basic branch with {{!comment}} AST test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if xxx}} a b {{!--comment  {{#if xxx}} abc {{/if}} --}} {{/if}}xxxxxxx";
             var ast = parser._buildBranchAst(s, 0);
             expect(ast.program[0].type).to.equal('branch');
@@ -399,8 +116,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.output).to.equal('{{#if xxx}} a b {{!comment  {{#if xxx}} abc {{/if}}');
         });
 
-        it("context-parser-handlebars - basic branch with inverse AST test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#basic branch with inverse AST test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if xxx}} a {{else}} b {{/if}}xxxxxxxx";
             var ast = parser._buildBranchAst(s, 0);
             expect(ast.program[0].type).to.equal('branch');
@@ -421,8 +138,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.output).to.equal('{{#if xxx}} a {{else}} b {{/if}}');
         });
 
-        it("context-parser-handlebars - nested branch AST test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#nested branch AST test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if xxx}} a {{#if yyy}} b {{else}} c {{/if}} d {{else}} e {{#if}} f {{else}} g {{/if}} h {{/if}}xxxxxx";
             var ast = parser._buildBranchAst(s, 0);
             expect(ast.program[0].type).to.equal('branch');
@@ -469,8 +186,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(r.output).to.equal('{{#if xxx}} a {{#if yyy}} b {{else}} c {{/if}} d {{else}} e {{#if}} f {{else}} g {{/if}} h {{/if}}');
         });
 
-        it("context-parser-handlebars - parallel branch AST test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#parallel branch AST test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if xxx}} a {{#if yyy}} b {{else}} c {{/if}} d {{#if}} e {{else}} f {{/if}} g {{/if}}xxxxxxx";
             var ast = parser._buildBranchAst(s, 0);
             expect(ast.program[0].type).to.equal('branch');
@@ -507,46 +224,93 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(ast.program[6].content).to.equal('{{/if}}');
             expect(ast.index).to.equal(86);
             var stateObj = parser.getInternalState();
+            stateObj.state = 1;
             var r = parser._analyseBranchAst(ast, stateObj);
             expect(r.output).to.equal('{{#if xxx}} a {{#if yyy}} b {{else}} c {{/if}} d {{#if}} e {{else}} f {{/if}} g {{/if}}');
         });
 
-        it("context-parser-handlebars - branch with <script> test", function() {
-            var parser = new ContextParserHandlebars();
+        it("context-parser-handlebars#branch with <script> test", function() {
+            var parser = new ContextParserHandlebars(config);
             var s = "{{#if}} <script> {{#if xxx}} path2 {{else}} path3 {{/if}} </script> {{else}} path4 {{/if}}";
             var ast = parser._buildBranchAst(s, 0);
             var stateObj = parser.getInternalState();
+            stateObj.state = 1;
             var r = parser._analyseBranchAst(ast, stateObj);
             expect(r.output).to.equal(s);
         });
 
-        /* handleRawBlock test
-           Please refer to "handlebars {{{{raw block}}}} test" in run-handlebars-3.0-spec.js */
-        it("context-parser-handlebars#_handleRawBlock test", function() {
-            [
-                // valid {{{{raw block}}}}
-                {str: '{{{{rawblock}}}} {{{{/rawblock}}}}      ', tag:'rawblock', result:33},
-                {str: '{{{{   rawblock}}}} {{{{/rawblock}}}}   ', tag:'rawblock', result:36},
-                {str: '{{{{rawblock   }}}} {{{{/rawblock}}}}   ', tag:'rawblock', result:36},
-                {str: '{{{{   rawblock   }}}} {{{{/rawblock}}}}', tag:'rawblock', result:39},
-
-                // invalid {{{{raw block}}}}
-                {str: '{{{{rawblockname}}}} xxx {{{{/    rawblockname}}}}', tag:'rawblockname',  result:false},
-                {str: '{{{{rawblockname}}}} xxx {{{{/rawblockname    }}}}', tag:'rawblockname',  result:false},
-                {str: '{{{{rawblockname1}}}} xxx {{{{/rawblockname2}}}}  ', tag:'rawblockname1', result:false},
-                {str: '{{{{rawblockname}}}} {{{{rawblock}}}} xxx {{{{/rawblock}}}} {{{{/rawblockname}}}}', tag:'rawblockname', result:false},
-
-            ].forEach(function(testObj) {
+        /* consumeExpression test */
+        it("context-parser-handlebars#_consumeExpression test", function() {
+            utils.partialExpressionTestPatterns.forEach(function(testObj) {
                 try {
-                    var parser = new ContextParserHandlebars();
-                    var r = parser._handleRawBlock(testObj.str, 0, testObj.tag);
-                    expect(r.index).to.equal(testObj.result);
+                    var parser = new ContextParserHandlebars(config);
+                    var r = parser._consumeExpression(testObj.syntax, 0, testObj.type, 1);
+                    expect(testObj.result[2]).to.equal(r.index);
                 } catch (e) {
-                    expect(false).to.equal(testObj.result);
+                    // guard against AssertionError, any good method to do it?
+                    expect(r).to.equal(undefined);
+                    expect(testObj.result[2]).to.equal(false);
+                }
+            });
+            utils.referenceExpressionTestPatterns.forEach(function(testObj) {
+                try {
+                    var parser = new ContextParserHandlebars(config);
+                    var r = parser._consumeExpression(testObj.syntax, 0, testObj.type, 1);
+                    expect(testObj.result[2]).to.equal(r.index);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(r).to.equal(undefined);
+                    expect(testObj.result[2]).to.equal(false);
                 }
             });
         });
 
+        /* handleRawExpression test */
+        it("context-parser-handlebars#_handleRawExpression test", function() {
+            utils.rawExpressionTestPatterns.forEach(function(testObj) {
+                try {
+                    var parser = new ContextParserHandlebars(config);
+                    var r = parser._consumeExpression(testObj.syntax, 0, testObj.type, false);
+                    expect(testObj.result[2]).to.equal(r.index);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(r).to.equal(undefined);
+                    expect(testObj.result[2]).to.equal(false);
+                }
+            });
+        });
+
+        /* handleRawBlock test */
+        it("context-parser-handlebars#_handleRawBlock test", function() {
+            utils.rawBlockTestPatterns.forEach(function(testObj) {
+                try {
+                    var parser = new ContextParserHandlebars(config);
+                    var r = parser._handleRawBlock(testObj.syntax, 0);
+                    expect(testObj.result[2]).to.equal(r.index);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(r).to.equal(undefined);
+                    expect(testObj.result[2]).to.equal(false);
+                }
+            });
+        });
+
+        /* handleCommentExpression test */
+        it("context-parser-handlebars#_handleCommentExpression test", function() {
+            utils.commentExpressionTestPatterns.forEach(function(testObj) {
+                try {
+                    var parser = new ContextParserHandlebars(config);
+                    var r = parser._consumeExpression(testObj.syntax, 0, testObj.type, false);
+                    expect(testObj.result[2]).to.equal(r.index);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(r).to.equal(undefined);
+                    expect(testObj.result[2]).to.equal(false);
+                }
+            });
+        });
+
+        /* handleTemplate test */
         it("context-parser-handlebars#_handleTemplate test", function() {
             // no need to test it directly
         });
@@ -578,8 +342,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 {s1:"<script>alert(0);", s2:"alert(0);</script>", result:false},
 
             ].forEach(function(testObj) {
-                var parser1 = new ContextParserHandlebars();
-                var parser2 = new ContextParserHandlebars();
+                var parser1 = new ContextParserHandlebars(config);
+                var parser2 = new ContextParserHandlebars(config);
                 var stateObj1, stateObj2;
                 parser1.contextualize(testObj.s1);
                 parser2.contextualize(testObj.s2);

--- a/tests/unit/run-filters.spec.js
+++ b/tests/unit/run-filters.spec.js
@@ -15,6 +15,9 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         utils = require('../utils.js'),
         ContextParserHandlebars = require("../../src/context-parser-handlebars");
 
+    var config = {};
+    config.printCharEnable = false;
+
     /* 
     * the following test make sure the correct filters/helpers are added to the hbs template
     */
@@ -409,7 +412,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it("Filter - subexpression format test", function() {
-            var t1 = new ContextParserHandlebars(false);
+            var t1 = new ContextParserHandlebars(config);
             var data = "<html><title>{{title}}</title></html>";
             t1.contextualize(data);
             var output = t1.getBuffer().join('');

--- a/tests/unit/run-handlebars-3.0-spec.js
+++ b/tests/unit/run-handlebars-3.0-spec.js
@@ -11,238 +11,135 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
     mocha = require("mocha");
     var expect = require('chai').expect,
+        utils = require('../utils.js'),
         handlebars = require('handlebars');
 
-    describe("Handlebars Parsing Test Suite", function() {
+    describe("Handlebars 3.0 Parsing Test Suite", function() {
 
-        /* we are not using handlebars to build the AST, so the following test can be skipped
-        *
-        it("handlebars {{expression}} test", function() {
-            [
-                '{{expression}}',
-                '{{expression}} }',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('mustache');
-            });
-            [
-                '{ {expression}}',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('content');
-            });
-        });
-
-        it("handlebars {{expression}} subexpression with \\r\\n test", function() {
-            [
-                '{{expression\rion}}',
-                '{{expression\nion}}',
-                '{{expression\r\nion}}',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('mustache');
-	        expect(ast.statements[0].params[0].string).to.equal('ion');
-	        expect(ast.statements[0].isHelper).to.equal(true);
-            });
-            ].forEach(function(testObj) {
+        /* Handlebars basic {{expression}} test */
+        it("handlebars basic {{expression}} test", function() {
+            utils.expressionTestPatterns.forEach(function(testObj) {
                 var ast;
                 try {
-                    ast = handlebars.parse(testObj.expression);
+                    ast = handlebars.parse(testObj.syntax);
                     expect(ast.body).to.be.ok;
-                    expect(ast.body[0].type).to.equal(testObj.result);
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
                 } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
                 }
             });
         });
 
-        /* we are not using handlebars to build the AST, so the following test can be skipped
-        *
-        it("handlebars {{expression}} test", function() {
-            [
-                '{{expression}}',
-                '{{expression}} }',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('mustache');
-            });
-            [
-                '{ {expression}}',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('content');
-            });
-        });
-
-        it("handlebars {{expression}} subexpression with \\r\\n test", function() {
-            [
-                '{{expression\rion}}',
-                '{{expression\nion}}',
-                '{{expression\r\nion}}',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('mustache');
-	        expect(ast.statements[0].params[0].string).to.equal('ion');
-	        expect(ast.statements[0].isHelper).to.equal(true);
-            });
-        });
-
-        it("handlebars invalid {{expression}} test", function() {
-            [
-                '{ {anything}}', 
-                '{{anything}', '{{anything} }', '{{anything}}}',
-                '{{    {anything}}', '{{    }anything}}',
-                '{{}}'
-            ].forEach(function(e) {
-                try {
-                    var ast = handlebars.parse(e);
-                    expect(false).to.equal(true);
-                } catch (err) {
-                    expect(true).to.equal(true);
-                }
-            });
-        });
-
+        /* Handlebars {{{raw expression}}} test */
         it("handlebars {{{raw expression}}} test", function() {
-            [
-                '{{{expression}}}',
-                '{{{expression}}} }',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('mustache');
-            });
-            [
-                '{ { {expression}}}',
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-	        expect(ast.statements[0].type).to.equal('content');
-            });
-        });
-
-        it("handlebars invalid {{{raw expression}}} test", function() {
-            [
-                '{ {{anything}}}', '{{ {anything}}}',
-                '{{{anything}', '{{{anything}}', '{{{anything}}}}',
-                '{{{    {anything}}}', '{{{    }anything}}}',
-                '{{{}}}'
-            ].forEach(function(e) {
+            utils.rawExpressionTestPatterns.forEach(function(testObj) {
+                var ast;
                 try {
-                    var ast = handlebars.parse(e);
-                    expect(false).to.equal(true);
-                } catch (err) {
-                    expect(true).to.equal(true);
-                }
-            });
-        });
-
-        it("handlebars white space control test", function() {
-            [
-                '{{#each nav ~}}\
-                    xxx\
-                {{~/each}}',
-                '{{#each nav ~}}\
-                    xxx\
-                {{~/   each}}'
-            ].forEach(function(t) {
-                var ast = handlebars.parse(t);
-                expect(ast.statements[0].program.statements[0].string).to.equal('xxx');
-            });
-            [
-                // cannot have space between ~ and }}
-                '{{#each nav ~   }}\
-                    xxx\
-                {{~/each}}',
-                // cannot have space between ~ and /
-                '{{#each nav ~}}\
-                    xxx\
-                {{~  /   each}}'
-            ].forEach(function(t) {
-                try {
-                    var ast = handlebars.parse(e);
-                    expect(false).to.equal(true);
-                } catch (err) {
-                    expect(true).to.equal(true);
+                    ast = handlebars.parse(testObj.syntax);
+                    expect(ast.body).to.be.ok;
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
                 }
             });
         });
 
         /* Handlebars {{{{raw block}}}} test */
         it("handlebars {{{{raw block}}}} test", function() {
-            [
-                // valid syntax
-                {
-                    syntax: '{{{{rawblockname}}}} xxx {{{{/rawblockname}}}}',
-                    result: 'BlockStatement',
-                },
-                {
-                    // it is fine to have space in the start rawblockname.
-                    syntax: '{{{{  rawblockname   }}}} xxx {{{{/rawblockname}}}}',
-                    result: 'BlockStatement',
-                },
-
-                // invalid syntax
-                // throw exception if {{{{rawblockname}}}} end with unbalanced } count.
-                { syntax: '{{{{rawblockname} xxx {{{{/rawblockname}}}}    ', result: false, },
-                { syntax: '{{{{rawblockname}} xxx {{{{/rawblockname}}}}   ', result: false, },
-                { syntax: '{{{{rawblockname}}} xxx {{{{/rawblockname}}}}  ', result: false, },
-                { syntax: '{{{{rawblockname}}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                {
-                    // throw exception if {{{{/rawblockname}}}} with space.
-                    syntax: '{{{{rawblockname}}}} xxx {{{{/    rawblockname}}}}',
-                    result: false,
-                },
-                {
-                    // throw exception if {{{{/rawblockname}}}} with space.
-                    syntax: '{{{{rawblockname}}}} xxx {{{{/rawblockname    }}}}',
-                    result: false,
-                },
-                {
-                    // throw exception if unbalanced {{{{rawblockname}}}}.
-                    syntax: '{{{{rawblockname1}}}} xxx {{{{/rawblockname2}}}}',
-                    result: false,
-                },
-                {
-                    // throw exception if another {{{{rawblock}}}} within another {{{{rawblock}}}}.
-                    syntax: '{{{{rawblockname}}}} {{{{rawblock}}}} xxx {{{{/rawblock}}}} {{{{/rawblockname}}}}',
-                    result: false,
-                },
-
-                // throw exception, {{{{rawblockname}}}} does not support special character and white space control.
-                // reference http://handlebarsjs.com/expressions.html
-                { syntax: '{{{{!rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{"rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { synatx: '{{{{#rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{%rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{&rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: "{{{{'rawblockname}}}} xxx {{{{/rawblockname}}}}", result: false, },
-                { syntax: '{{{{(rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{)rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{*rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{+rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{,rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{.rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{/rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{;rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{>rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{=rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{<rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{@rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{[rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{^rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{]rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{`rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{{rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{}rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{~rawblockname}}}} xxx {{{{/rawblockname}}}}', result: false, },
-                { syntax: '{{{{rawblockname~}}}} xxx {{{{/rawblockname}}}}', result: false, },
-
-            ].forEach(function(testObj) {
+            utils.rawBlockTestPatterns.forEach(function(testObj) {
                 var ast;
                 try {
                     ast = handlebars.parse(testObj.syntax);
                     expect(ast.body).to.be.ok;
-                    expect(ast.body[0].type).to.equal(testObj.result);
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
                 } catch (e) {
-                    expect(testObj.result).to.equal(false);
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
+                }
+            });
+        });
+
+        /* Handlebars {{escape expression}} test */
+        it("handlebars {{escape expression}} test", function() {
+            utils.escapeExpressionTestPatterns.forEach(function(testObj) {
+                var ast;
+                try {
+                    ast = handlebars.parse(testObj.syntax);
+                    expect(ast.body).to.be.ok;
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
+                }
+            });
+        });
+
+        /* Handlebars {{>partial}} test */
+        it("handlebars {{>partial}} test", function() {
+            utils.partialExpressionTestPatterns.forEach(function(testObj) {
+                var ast;
+                try {
+                    ast = handlebars.parse(testObj.syntax);
+                    expect(ast.body).to.be.ok;
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
+                }
+            });
+        });
+
+        /* Handlebars {{&reference}} test */
+        it("handlebars {{&reference}} test", function() {
+            utils.referenceExpressionTestPatterns.forEach(function(testObj) {
+                var ast;
+                try {
+                    ast = handlebars.parse(testObj.syntax);
+                    expect(ast.body).to.be.ok;
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
+                }
+            });
+        });
+
+        /* Handlebars {{[#|^]branch}} test */
+        it("handlebars {{[#|^]branch}} test", function() {
+            utils.branchExpressionTestPatterns.forEach(function(testObj) {
+                var ast;
+                try {
+                    ast = handlebars.parse(testObj.syntax);
+                    expect(ast.body).to.be.ok;
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
+                }
+            });
+        });
+
+        /* Handlebars {{!comment}} test */
+        it("handlebars {{!comment}} test", function() {
+            utils.commentExpressionTestPatterns.forEach(function(testObj) {
+                var ast;
+                try {
+                    ast = handlebars.parse(testObj.syntax);
+                    expect(ast.body).to.be.ok;
+                    expect(testObj.result[0]).to.equal(ast.body[0].type);
+                } catch (e) {
+                    // guard against AssertionError, any good method to do it?
+                    expect(ast).to.equal(undefined); 
+                    expect(testObj.result[0]).to.equal(false);
                 }
             });
         });

--- a/tests/unit/run-utils-spec.js
+++ b/tests/unit/run-utils-spec.js
@@ -17,379 +17,116 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
     describe("handlebars-utils test suite", function() {
 
-        it("handlebars-utils#getExpressionType test", function() {
-        });
-
-        it("handlebars-utils#isValidExpression escapeExpressionRegExp test", function() {
+        /* lookAheadTest */
+        it("handlebars-utils#lookAheadTest test", function() {
             [
-                // basic
-                {str:'{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{anything}}'},
-                {str:'{{   anything   }}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{   anything   }}'},
-                // with \r and \n
-                {str:'{{any\rthing}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\rthing}}'},
-                {str:'{{any\nthing}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\nthing}}'},
-                {str:'{{any\r\nthing}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\r\nthing}}'},
+                {str:'{{#xxxxxxxx   ', type:handlebarsUtils.BRANCH_EXPRESSION},
+                {str:'{{^xxxxxxxx   ', type:handlebarsUtils.BRANCH_EXPRESSION},
+                {str:'{{/xxxxxxxx   ', type:handlebarsUtils.BRANCH_END_EXPRESSION},
+                {str:'{{>xxxxxxxx   ', type:handlebarsUtils.PARTIAL_EXPRESSION},
+                {str:'{{!--xxxxxx   ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM},
+                {str:'{{!xxxxxxxx   ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM},
 
-                {str:'{{any\'thing\'}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\'thing\'}}'},
-                {str:"{{any'thing'}}", type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:"{{any'thing'}}"},
-                {str:"{{~any'thing'~}}", type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:"{{~any'thing'~}}"},
-                {str:'{{any"thing"}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any"thing"}}'},
-
-                // with ~
-                {str:'{{~anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{~anything}}'},
-                {str:'{{~anything~}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{~anything~}}'},
-                {str:'{{~  anything  ~}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{~  anything  ~}}'},
-
-                // invalid reserved expression
-                {str:'{{#anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~#anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{/anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~/anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{@anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~@anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{^anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~^anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{!anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~!anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{!--anything--}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~!--anything--}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{>anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{~>anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-
-                // invalid expression
-                {str:'{ {anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{anything}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{anything} }', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{anything}}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{    {anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{    }anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{    ~anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-                {str:'{{}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:false},
-
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
-                utils.testIsValidExpression(r, obj); 
+                {str:'{{~#xxxxxxxx  ', type:handlebarsUtils.BRANCH_EXPRESSION},
+                {str:'{{~^xxxxxxxx  ', type:handlebarsUtils.BRANCH_EXPRESSION},
+                {str:'{{~/xxxxxxxx  ', type:handlebarsUtils.BRANCH_END_EXPRESSION},
+                {str:'{{~>xxxxxxxx  ', type:handlebarsUtils.PARTIAL_EXPRESSION},
+                {str:'{{~!--xxxxxx  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM},
+                {str:'{{~!xxxxxxxx  ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM},
+            ].forEach(function(testObj) {
+                var r = handlebarsUtils.lookAheadTest(testObj.str, 0);
+                expect(r).to.equal(testObj.type);
             });
         });
 
+        /* isValidExpression rawExpressionRegExp test */
         it("handlebars-utils#isValidExpression rawExpressionRegExp test", function() {
-            [
-                // basic
-                {str:'{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{anything}}}'},
-                {str:'{{{   anything   }}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{   anything   }}}'},
-                // with \r and \n
-                {str:'{{{any\rthing}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\rthing}}}'},
-                {str:'{{{any\nthing}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\nthing}}}'},
-                {str:'{{{any\r\nthing}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\r\nthing}}}'},
-
-                // with ~
-                {str:'{{{~anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{~anything}}}'},
-                {str:'{{{~anything~}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{~anything~}}}'},
-                {str:'{{{~  anything  ~}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{~  anything  ~}}}'},
-
-                // invalid expression
-                {str:'{ {{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{ {anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{anything}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{anything}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{anything}}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{   {anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{   }anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{   ~anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false},
-                {str:'{{{}}}', type:handlebarsUtils.RAW_EXPRESSION, result:false}
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
-                utils.testIsValidExpression(r, obj); 
-            });
-        });
-
-        it("handlebars-utils#isValidExpression greedy match test", function() {
-            [
-                // basic
-                {str:'{{anything}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{anything}}'},
-                {str:'{{   anything   }}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{   anything   }}'},
-                {str:'{{anything}}xxx{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{anything}}'},
-                {str:'{{   anything   }}xxx{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{   anything   }}'},
-
-                // with \r and \n
-                {str:'{{any\rthing}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\rthing}}'},
-                {str:'{{any\nthing}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\nthing}}'},
-                {str:'{{any\r\nthing}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{any\r\nthing}}'},
-
-                // with ~
-                {str:'{{~anything}}{{anything}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{~anything}}'},
-                {str:'{{~anything~}}{{~anything~}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{~anything~}}'},
-                {str:'{{~  anything  ~}}{{~  anything  ~}}', type:handlebarsUtils.ESCAPE_EXPRESSION, result:true, rstr:'{{~  anything  ~}}'},
-
-                // basic
-                {str:'{{{anything}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{anything}}}'},
-                {str:'{{{   anything   }}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{   anything   }}}'},
-                {str:'{{{anything}}}xxx{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{anything}}}'},
-                {str:'{{{   anything   }}}xxx{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{   anything   }}}'},
-
-                // with \r and \n
-                {str:'{{{any\rthing}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\rthing}}}'},
-                {str:'{{{any\nthing}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\nthing}}}'},
-                {str:'{{{any\r\nthing}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{any\r\nthing}}}'},
-
-                // with ~
-                {str:'{{{~anything}}}{{{anything}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{~anything}}}'},
-                {str:'{{{~anything~}}}{{{~anything~}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{~anything~}}}'},
-                {str:'{{{~  anything  ~}}}{{{~  anything  ~}}}', type:handlebarsUtils.RAW_EXPRESSION, result:true, rstr:'{{{~  anything  ~}}}'},
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
-                utils.testIsValidExpression(r, obj); 
-            });
-        });
-
-        it("handlebars-utils#isValidExpression partialExpressionRegExp test", function() {
-            var arr = [
-                // basic
-                {str:'{{>anything}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{>anything}}'},
-                {str:'{{>   anything   }}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{>   anything   }}'},
-                // with \r and \n
-                {str:'{{>any\rthing}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{>any\rthing}}'},
-                {str:'{{>any\nthing}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{>any\nthing}}'},
-                {str:'{{>any\r\nthing}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{>any\r\nthing}}'},
-
-                // with ~
-                {str:'{{~>anything}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{~>anything}}'},
-                {str:'{{~>anything~}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{~>anything~}}'},
-                {str:'{{~>  anything  ~}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:true, rstr:'{{~>  anything  ~}}'},
-
-                // invalid 
-                {str:'{{@anything}}', type:handlebarsUtils.PARTIAL_EXPRESSION, result:false},
-            ];
-            arr.forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
-                utils.testIsValidExpression(r, obj); 
-            });
-        });
-
-        it("handlebars-utils#isValidExpression dataVarExpressionRegExp test", function() {
-            [
-                // basic
-                {str:'{{@anything}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{@anything}}'},
-                {str:'{{@   anything   }}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{@   anything   }}'},
-                // with \r and \n
-                {str:'{{@any\rthing}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{@any\rthing}}'},
-                {str:'{{@any\nthing}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{@any\nthing}}'},
-                {str:'{{@any\r\nthing}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{@any\r\nthing}}'},
-
-                // with ~
-                {str:'{{~@anything}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{~@anything}}'},
-                {str:'{{~@anything~}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{~@anything~}}'},
-                {str:'{{~@  anything  ~}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:true, rstr:'{{~@  anything  ~}}'},
-
-                // invalid 
-                {str:'{{>anything}}', type:handlebarsUtils.DATA_VAR_EXPRESSION, result:false},
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, obj.type);
-                utils.testIsValidExpression(r, obj); 
-            });
-        });
-
-        it("handlebars-utils#isValidExpression branchExpressionRegExp test", function() {
-            [
-                {str: '{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{#if xxx}}{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{#if xxx}}x{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{#if xxx}} x {{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{#   if   xxx}}', rstr: 'if', result: true},
-
-                {str: '{{~#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx}}{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx}}x{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx}} x {{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#   if   xxx}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx~}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx~}}{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx~}}x{{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#if xxx~}} x {{#if xxx}}', rstr: 'if', result: true},
-                {str: '{{~#   if   xxx~}}', rstr: 'if', result: true},
-
-                {str: '{{#with xxx}}', rstr: 'with', result: true},
-                {str: '{{#each xxx}}', rstr: 'each', result: true},
-                {str: '{{#list xxx}}', rstr: 'list', result: true},
-                {str: '{{#unless xxx}}', rstr: 'unless', result: true},
-                {str: '{{#tag xxx}}', rstr: 'tag', result: true},
-                {str: '{{^msg xxx}}', rstr: 'msg', result: true},
-
-                {str: '{{~^msg xxx}}', rstr: 'msg', result: true},
-
-                {str: '{{^}}', rstr: false, result: false},
-                {str: '{{~^}}', rstr: false, result: false},
-                {str: '{{~^~}}', rstr: false, result: false},
-                {str: '{{~  ^  ~}}', rstr: false, result: false},
-
-                {str: '{{else}}', rstr: false, result:false},
-                {str: '{{^}}', rstr: false, result:false},
-                {str: '{{expression}}', rstr: false, result:false},
-                {str: '{{@partial}}', rstr: false, result:false},
-                {str: '{{{expression}}}', rstr: false, result:false},
-
-                // illegal handlebars format
-                {str: '{{#t-ag xxx}}', rstr: 't-ag', result: true}
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, handlebarsUtils.BRANCH_EXPRESSION);
-                expect(r.tag).to.equal(obj.rstr);
-                expect(r.result).to.equal(obj.result);
-            });
-        });
-
-        it("handlebars-utils#isValidExpression branchEndExpressionRegExp test", function() {
-            [
-                {str: '{{/if}}', rstr: 'if', result: true},
-                {str: '{{/if}}{{/if}}', rstr: 'if', result: true},
-                {str: '{{/if}}x{{/if}}', rstr: 'if', result: true},
-                {str: '{{/if}} x {{/if}}', rstr: 'if', result: true},
-                {str: '{{/   if   }}', rstr: 'if', result: true},
-
-                {str: '{{~/if}}', rstr: 'if', result: true},
-                {str: '{{~/if}}{{/if}}', rstr: 'if', result: true},
-                {str: '{{~/if}}x{{/if}}', rstr: 'if', result: true},
-                {str: '{{~/if}} x {{/if}}', rstr: 'if', result: true},
-                {str: '{{~/   if   }}', rstr: 'if', result: true},
-                {str: '{{~/if~}}', rstr: 'if', result: true},
-                {str: '{{~/if~}}{{/if}}', rstr: 'if', result: true},
-                {str: '{{~/if~}}x{{/if}}', rstr: 'if', result: true},
-                {str: '{{~/if~}} x {{/if}}', rstr: 'if', result: true},
-                {str: '{{~/   if   ~}}', rstr: 'if', result: true},
-
-                {str: '{{/with}}', rstr: 'with', result: true},
-                {str: '{{/each}}', rstr: 'each', result: true},
-                {str: '{{/list}}', rstr: 'list', result: true},
-                {str: '{{/unless}}', rstr: 'unless', result: true},
-                {str: '{{/tag}}', rstr: 'tag', result: true},
-                {str: '{{/msg}}', rstr: 'msg', result: true},
-
-                // illegal handlebars format
-                {str: '{{/t-ag}}', rstr: 't-ag', result: true}
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, handlebarsUtils.BRANCH_END_EXPRESSION);
-                expect(r.tag).to.equal(obj.rstr);
-                expect(r.result).to.equal(obj.result);
-            });
-        });
-
-        it("handlebars-utils#isValidExpression elseExpressionRegExp test", function() {
-            [
-                {str: '{{else}}', result:true},
-                {str: '{{   else   }}', result:true},
-                {str: '{{else}}{{else}}', result:true},
-                {str: '{{else}}x{{else}}', result:true},
-                {str: '{{else}} x {{else}}', result:true},
-
-                {str: '{{~else~}}', result:true},
-                {str: '{{~   else   ~}}', result:true},
-                {str: '{{~else~}}{{~else~}}', result:true},
-                {str: '{{~else~}}x{{~else~}}', result:true},
-                {str: '{{~else~}} x {{~else~}}', result:true},
-
-                {str: '{{^}}', result:true},
-                {str: '{{~^~}}', result:true},
-                {str: '{{~   ^   ~}}', result:true},
-                {str: '{{^   }}', result:true},
-                {str: '{{^   ~}}', result:true},
-                {str: '{{^}}{{^}}', result:true},
-                {str: '{{^}}x{{^}}', result:true},
-                {str: '{{^}} x {{^}}', result:true},
-                {str: '{{~^~}}{{~^~}}', result:true},
-
-                {str: '{{^msg}}', result:false},
-                {str: '{{^msg ~}}', result:false},
-                {str: '{{^   msg}}', result:false},
-                {str: '{{^   msg   }}', result:false}
-            ].forEach(function(obj) {
-                var r = handlebarsUtils.isValidExpression(obj.str, 0, handlebarsUtils.ELSE_EXPRESSION);
-                expect(r.result).to.equal(obj.result);
+            utils.rawExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
             });
         });
 
         /* isValidExpression rawBlockRegExp test
            Please refer to "handlebars {{{{raw block}}}} test" in run-handlebars-3.0-spec.js */
         it("handlebars-utils#isValidExpression rawBlockRegExp test", function() {
-            [
-                // valid {{{{rawblock}}}} syntax
-                {str:'{{{{rawblockname}}}}     ', type:handlebarsUtils.RAW_BLOCK, result:true, rstr:'rawblockname'},
-                {str:'{{{{   rawblockname}}}}  ', type:handlebarsUtils.RAW_BLOCK, result:true, rstr:'rawblockname'},
-                {str:'{{{{rawblockname     }}}}', type:handlebarsUtils.RAW_BLOCK, result:true, rstr:'rawblockname'},
-                {str:'{{{{   rawblockname  }}}}', type:handlebarsUtils.RAW_BLOCK, result:true, rstr:'rawblockname'},
+            utils.rawBlockTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                if (r.result) {
+                    expect(r.result).to.equal(testObj.result[1]);
+                } else {
+                    expect(r.result).to.equal(testObj.result[1]);
+                    expect(r.tag).to.equal(testObj.rstr);
+                }
+            });
+            utils.rawEndBlockTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+            });
+        });
 
-                // invalid {{{{rawblock}}}} syntax
-                {str:'{{{{rawblockname}    ', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{rawblockname}}   ', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{rawblockname}}}  ', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{rawblockname}}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
+        /* isValidExpression escapeExpressionRegExp test */
+        it("handlebars-utils#isValidExpression escapeExpressionRegExp test", function() {
+            utils.escapeExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+                expect(r.isSingleID).to.equal(testObj.isSingleID);
+            });
+        });
 
-                {str:'{{{{!rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{"rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{#rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{%rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{&rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:"{{{{'rawblockname}}}}", type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{(rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{)rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{*rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{+rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{,rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{.rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{;rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{>rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{=rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{<rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{@rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{[rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{]rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{`rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{{rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{}rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{~rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
-                {str:'{{{{rawblockname~}}}}', type:handlebarsUtils.RAW_BLOCK, result:false, rstr:false},
+        /* isValidExpression referenceExpressionRegExp test */
+        it("handlebars-utils#isValidExpression referenceExpressionRegExp test", function() {
+            utils.referenceExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+            });
+        });
+   
+        /* isValidExpression partialExpressionRegExp test */
+        it("handlebars-utils#isValidExpression partialExpressionRegExp test", function() {
+            utils.partialExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+            });
+        });
+   
+        /* isValidExpression branchExpressionRegExp test */
+        it("handlebars-utils#isValidExpression branchExpressionRegExp test", function() {
+            utils.branchExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+            });
+        });
 
-                // valid {{{{/rawblock}}}} syntax
-                {str:'{{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:true, rstr:'rawblockname'},
+        /* isValidExpression branchEndExpressionRegExp test */
+        it("handlebars-utils#isValidExpression branchEndExpressionRegExp test", function() {
+            utils.branchEndExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+            });
+        });
 
-                // invalid {{{{/rawblock}}}} syntax
-                {str:'{{{{/   rawblockname}}}}   ', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{/rawblockname      }}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{/   rawblockname   }}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
+        /* isValidExpression elseExpressionRegExp test */
+        it("handlebars-utils#isValidExpression elseExpressionRegExp test", function() {
+            utils.elseExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
+                expect(r.tag).to.equal(testObj.rstr);
+            });
+        });
 
-                {str:'{{{{/rawblockname}    ', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{/rawblockname}}   ', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{/rawblockname}}}  ', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{/rawblockname}}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-
-                {str:'{{{{!rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{"rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{#rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{%rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{&rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:"{{{{'rawblockname}}}}", type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{(rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{)rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{*rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{+rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{,rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{.rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                /* {str:'{{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false}, */
-                {str:'{{{{;rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{>rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{=rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{<rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{@rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{[rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{]rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{`rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{{rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{}rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{~rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-                {str:'{{{{rawblockname~}}}}', type:handlebarsUtils.RAW_END_BLOCK, result:false, rstr:false},
-
-            ].forEach(function(testObj) {
-                var r = handlebarsUtils.isValidExpression(testObj.str, 0, testObj.type);
-                expect(r.result).to.equal(testObj.result);
+        /* isValidExpression commentExpressionRegExp test */
+        it("handlebars-utils#isValidExpression commentExpressionRegExp test", function() {
+            utils.commentExpressionTestPatterns.forEach(function(testObj) {
+                var r = handlebarsUtils.isValidExpression(testObj.syntax, 0, testObj.type);
+                expect(r.result).to.equal(testObj.result[1]);
                 expect(r.tag).to.equal(testObj.rstr);
             });
         });
@@ -398,16 +135,16 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         it("handlebars-utils#isReservedChar test", function() {
             /* reserved char we care about */
             [
-                '#', '/', '>', '@', '^', '!',
-                '~#', '~/', '~>', '~@', '~^', '~!'
+                '#', '/', '>', '^', '!', '&',
+                '~#', '~/', '~>', '~^', '~!', '~&',
             ].forEach(function(testObj) {
                 var r = handlebarsUtils.isReservedChar(testObj, 0);
                 expect(r).to.equal(true);
             });
             /* reserved char we don't care about */
             [
-                ' ', '"', '%', '&', "'", '(', ')', '*', '+', ',', '.', '<', '=', '[', ']', '`', '{', '|', '}',
-                '~ ', '~"', '~%', '~&', "~'", '~(', '~)', '~*', '~+', '~,', '~.', '~<', '~=', '~[', '~]', '~`', '~{', '~|', '~}',
+                ' ', '"', '%', "'", '(', ')', '*', '+', ',', '.', '<', '=', '@', '[', ']', '`', '{', '|', '}',
+                '~ ', '~"', '~%', "~'", '~(', '~)', '~*', '~+', '~,', '~.', '~<', '~=', '~@', '~[', '~]', '~`', '~{', '~|', '~}',
             ].forEach(function(testObj) {
                 var r = handlebarsUtils.isReservedChar(testObj, 0);
                 expect(r).to.equal(false);

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,29 +1,17 @@
 /*
-Copyright (c) 2015, Yahoo! Inc. All rights reserved.
+Copyright (c) 2015, Yahoo Inc. All rights reserved.
 Copyrights licensed under the New BSD License.
 See the accompanying LICENSE file for terms.
 */
 (function() {
 
-var expect = require('chai').expect;
+var expect = require('chai').expect,
+    handlebarsUtils = require('../src/handlebars-utils');
 
 exports.testArrMatch = function(data, arr) {
    arr.forEach(function(p) {
        expect(data).to.match(p);
    });
-};
-
-exports.testExpression = function(result, obj) {
-    expect(result.isPrefixWithKnownFilter).to.equal(obj.isPrefixWithKnownFilter);
-    expect(result.filter).to.equal(obj.filter);
-    expect(result.isSingleIdentifier).to.equal(obj.isSingleIdentifier);
-};
-
-exports.testIsValidExpression = function(result, obj) {
-    if (obj.hasOwnProperty('rstr')) {
-        expect(result[0]).to.equal(obj.rstr);
-    }
-    expect(result.result).to.equal(obj.result);
 };
 
 exports.append_zero = function(i) {
@@ -33,5 +21,515 @@ exports.append_zero = function(i) {
     }
     return s;
 };
+
+// for handlebars-3.0-spec test only
+var expressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{escapeexpression}}  ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ]},
+    { syntax: '{{&escapeexpression}} ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ]},
+    { syntax: '{{~escapeexpression}} ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ]},
+    { syntax: '{{!commentexpression}}', type: '', rstr: '', result: [ 'CommentStatement',  '', '' ]},
+    { syntax: '{{#branchexpression}} {{/branchexpression}}', type: '', rstr: '', result: [ 'BlockStatement', '', '' ]},
+    { syntax: '{{>partialexpression}}', type: '', rstr: '', result: [ 'PartialStatement',  '', '' ]},
+
+    // data var is not a special place holder
+    { syntax: '{{@datavar}}         ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ], },
+    { syntax: '{{@datavar @datavar}}', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ], },
+    { syntax: '{{  @datavar}}       ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ], },
+    { syntax: '{{@  datavar}}       ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ], },
+    { syntax: '{{  @  datavar}}     ', type: '', rstr: '', result: [ 'MustacheStatement', '', '' ], },
+
+    { syntax: '{{   &expression}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: '{{   ~expression}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: '{{   !expression}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: '{{   #expression}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: '{{#expression}} {{    /expression}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: '{{   >expression}}', type: '', rstr: '', result: [ false, '', '']},
+
+    // invalid reserved char
+    { syntax: '{{"xxx}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: '{{%xxx}}', type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{'xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{(xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{)xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{*xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{+xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{,xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{.xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    // standalone will fail the case
+    { syntax: "{{/xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{;xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{<xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{=xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{[xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{\\xxx}}",type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{]xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    // standalone will fail the case
+    { syntax: "{{^xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{{xxx}}", type: '', rstr: '', result: [ false, '', '']},
+    { syntax: "{{}xxx}}", type: '', rstr: '', result: [ false, '', '']},
+];
+exports.expressionTestPatterns = expressionTestPatterns;
+
+var rawExpressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{{rawexpression}}}        ', type:handlebarsUtils.RAW_EXPRESSION, rstr: 'rawexpression', result: [ 'MustacheStatement', true, 18 ]},
+    // it is fine to have space in the raw expression.
+    { syntax: '{{{   rawexpression   }}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr: 'rawexpression', result: [ 'MustacheStatement', true, 24 ]},
+    // for non-greedy match
+    { syntax: '{{{rawexpression}}} {{{rawexpression}}}', type:handlebarsUtils.RAW_EXPRESSION, rstr: 'rawexpression', result: [ 'MustacheStatement', true, 18 ]},
+    // data var is not a special place holder
+    { syntax: '{{{@rawexpression}}}       ', type:handlebarsUtils.RAW_EXPRESSION, rstr: 'rawexpression', result: [ 'MustacheStatement', true, 19 ]},
+    { syntax: '{{{  @rawexpression}}}     ', type:handlebarsUtils.RAW_EXPRESSION, rstr: 'rawexpression', result: [ 'MustacheStatement', true, 21 ]},
+
+    // invalid syntax
+    // new line char test
+    // the util test and rstr test is incorrect
+    { syntax: '{{{raw\rexpression}}}   ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'raw', result: [ 'MustacheStatement', true, 19 ]},
+    { syntax: '{{{raw\nexpression}}}   ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'raw', result: [ 'MustacheStatement', true, 19 ]},
+    // data var, the util test and rstr test is incorrect
+    { syntax: '{{{@  rawexpression}}}    ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'rawexpression', result: [ 'MustacheStatement', true, 21 ]},
+    { syntax: '{{{  @  rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'rawexpression', result: [ 'MustacheStatement', true, 23 ]},
+
+    { syntax: '{{{rawexpression}     ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{rawexpression}}    ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{rawexpression}}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, 18    ]},
+    { syntax: '{{{rawexpression}} }  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{rawexpression} }}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{ {{rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, 19     ]},
+    { syntax: '{{ {rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, 19     ]},
+
+    { syntax: '{ { {rawexpression}}} ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ 'ContentStatement', false, 20 ]},
+    { syntax: '{{{rawexpression} } } ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{}}}                ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, 5     ]},
+
+    { syntax: '{{{ }rawexpression}}} ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, 20    ]},
+    { syntax: '{{{ {rawexpression}}} ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false, result: [ false, false, 20    ]},
+
+    // throw exception, {{{rawexpression}}} does not support special character and white space control.
+    // reference http://handlebarsjs.com/expressions.html
+    { syntax: '{{{@rawexpression @rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'rawexpression', result: [ 'MustacheStatement', true, 34 ]},
+    // even though handlebars does not support, i don't care to let it pass util test
+    { syntax: '{{{!rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'!rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{#rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'#rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{%rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'%rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{&rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'&rawexpression', result: [ false, true, 19 ]},
+    { syntax: "{{{'rawexpression}}}  ", type:handlebarsUtils.RAW_EXPRESSION, rstr:"'rawexpression", result: [ false, true, 19 ]},
+    { syntax: '{{{(rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'(rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{)rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:')rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{*rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'*rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{+rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'+rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{,rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:',rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{.rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'.rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{/rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'/rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{;rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:';rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{>rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'>rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{=rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'=rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{<rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'<rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{[rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'[rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{^rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'^rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{]rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:']rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{`rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'`rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{{rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false,            result: [ false, false, 19 ]},
+    { syntax: '{{{}rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:false,            result: [ false, false, 19 ]},
+    { syntax: '{{{~rawexpression}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'rawexpression', result: [ false, true, 19 ]},
+    { syntax: '{{{rawexpression~}}}  ', type:handlebarsUtils.RAW_EXPRESSION, rstr:'rawexpression', result: [ false, true, 19 ]},
+];
+exports.rawExpressionTestPatterns = rawExpressionTestPatterns;
+
+var rawBlockTestPatterns = [
+    // valid syntax
+    { syntax: '{{{{rawblockname}}}} xxx {{{{/rawblockname}}}}      ', type:handlebarsUtils.RAW_BLOCK, rstr:'rawblockname', result: [ 'BlockStatement', true, 45 ]},
+    // it is fine to have space in the start rawblockname.
+    { syntax: '{{{{  rawblockname   }}}} xxx {{{{/rawblockname}}}} ', type:handlebarsUtils.RAW_BLOCK, rstr:'rawblockname', result: [ 'BlockStatement', true, 50 ]},
+    // handlebars allows this syntax and the fifth } is part of content inside raw block
+    { syntax: '{{{{rawblockname}}}}} xxx {{{{/rawblockname}}}}     ', type:handlebarsUtils.RAW_BLOCK, rstr:'rawblockname', result: [ 'BlockStatement', true, 46 ]},
+
+    // invalid syntax
+    // new line char test
+    { syntax: '{{{{raw\rblockname}}}} xxx {{{{/rawblockname}}}}    ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{raw\nblockname}}}} xxx {{{{/rawblockname}}}}    ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    // utils test can be true as it only parses the first expression.
+    { syntax: '{{{{rawblockname}}}} xxx {{{{/raw\rblockname}}}}    ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, true, false ]},
+    { syntax: '{{{{rawblockname}}}} xxx {{{{/raw\nblockname}}}}    ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, true, false ]},
+    // throw exception if {{{{rawblockname}}}} end with unbalanced } count.
+    { syntax: '{{{{rawblockname} xxx {{{{/rawblockname}}}}         ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{rawblockname}} xxx {{{{/rawblockname}}}}        ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{rawblockname}}} xxx {{{{/rawblockname}}}}       ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    // throw exception if {{{{/rawblockname}}}} with space.
+    // the utils test can be true as it only parses the first expression.
+    { syntax: '{{{{rawblockname}}}} xxx {{{{/    rawblockname}}}}  ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, true, false ]},
+    { syntax: '{{{{rawblockname}}}} xxx {{{{/rawblockname    }}}}  ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, true, false ]},
+    // throw exception if unbalanced {{{{rawblockname}}}}.
+    // the utils test can be true as it only parses the first expression.
+    { syntax: '{{{{rawblockname1}}}} xxx {{{{/rawblockname2}}}}    ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, true, false ]},
+    // throw exception if another {{{{rawblock}}}} within another {{{{rawblock}}}}.
+    // the utils test can be true as it only parses the first expression.
+    { syntax: '{{{{rawblockname}}}} {{{{rawblock}}}} xxx {{{{/rawblock}}}} {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, true, false ]},
+
+    // throw exception, {{{{rawblockname}}}} does not support special character and white space control.
+    // reference http://handlebarsjs.com/expressions.html
+    { syntax: '{{{{!rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{"rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{#rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{%rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{&rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: "{{{{'rawblockname}}}} xxx {{{{/rawblockname}}}}", type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{(rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{)rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{*rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{+rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{,rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{.rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{/rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{;rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{>rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{=rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{<rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{@rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{[rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{^rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{]rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{`rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{{rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{}rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{~rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{{{rawblockname~}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ false, false, false ]},
+];
+exports.rawBlockTestPatterns = rawBlockTestPatterns;
+
+var rawEndBlockTestPatterns = [
+    // valid syntax
+    { syntax: '{{{{/rawblockname}}}}     ', type:handlebarsUtils.RAW_END_BLOCK, rstr: 'rawblockname', result: [ '', true, '' ]},
+
+    // invalid syntax
+    // new line char test
+    { syntax: '{{{{/raw\rblockname}}}}   ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/raw\nblockname}}}}   ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/rawblockname}        ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/rawblockname}}       ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/rawblockname}}}      ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/rawblockname}}}}}    ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+
+    { syntax: '{{{{/    rawblockname}}}} ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/rawblockname    }}}} ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{/  rawblockname  }}}} ', type:handlebarsUtils.RAW_BLOCK, rstr:false, result: [ '', false, '' ]},
+
+    // throw exception, {{{{/rawblockname}}}} does not support special character and white space control.
+    // reference http://handlebarsjs.com/expressions.html
+    { syntax: '{{{{!rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{"rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{#rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{%rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{&rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: "{{{{'rawblockname}}}} xxx {{{{/rawblockname}}}}", type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{(rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{)rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{*rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{+rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{,rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{.rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    // valid syntax for raw end block
+    // { syntax: '{{{{/rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{;rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{>rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{=rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{<rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{@rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{[rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{^rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{]rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{`rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{{rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{}rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{~rawblockname}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+    { syntax: '{{{{rawblockname~}}}} xxx {{{{/rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+
+    { syntax: '{{{{rawblockname}}}} xxx {{{{/@rawblockname}}}}', type:handlebarsUtils.RAW_END_BLOCK, rstr:false, result: [ '', false, '' ]},
+];
+exports.rawEndBlockTestPatterns = rawEndBlockTestPatterns;
+
+var escapeExpressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{expression}}               ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'expression', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // it is fine to have space in the expression
+    { syntax: '{{  expression   }}          ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'expression', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // it is fine to have whitespace control in the expression.
+    { syntax: '{{~ expression  ~}}          ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'expression', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // private variable  
+    { syntax: '{{@expression}}              ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'expression', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // private variable with space before  
+    { syntax: '{{@  expression  }}          ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'expression', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // private variable with space after/before  
+    { syntax: '{{  @  expression  }}        ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'expression', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // dot as the ID
+    { syntax: '{{.}}                        ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: '.',          isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // with / as separator 
+    { syntax: '{{../name}}                  ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: '../name',    isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    { syntax: '{{../name ../name}}          ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: '../name',    isSingleID: false, result: [ 'MustacheStatement', true, 11 ]},
+    // with dot as separator 
+    { syntax: '{{article.title}}            ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'article.title', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // with / as separator 
+    { syntax: '{{article/title}}            ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'article/title', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // with dot as separator and index
+    { syntax: '{{article.[10].[#comments]}} ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'article.[10].[#comments]', isSingleID: true, result: [ 'MustacheStatement', true, 11 ]},
+    // 2 expressions
+    { syntax: '{{exp1 exp2}}                ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'exp1', isSingleID: false, result: [ 'MustacheStatement', true, 11 ]},
+    // 3 expressions
+    { syntax: '{{exp1 exp2 exp3}}           ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'exp1', isSingleID: false, result: [ 'MustacheStatement', true, 11 ]},
+    // expression with param
+    { syntax: '{{exp1 (param1)}}            ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'exp1', isSingleID: false, result: [ 'MustacheStatement', true, 11 ]},
+    // expression with data param
+    { syntax: '{{exp1 (@param1)}}           ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'exp1', isSingleID: false, result: [ 'MustacheStatement', true, 11 ]},
+    // expression with 2 params
+    { syntax: '{{exp1 (param1 param2)}}     ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'exp1', isSingleID: false, result: [ 'MustacheStatement', true, 11 ]},
+
+    // reserved char
+    { syntax: '{{/exp1}}                    ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: false, isSingleID: false, result: [ false, false, 11 ]},
+    { syntax: '{{#exp1}}                    ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: false, isSingleID: false, result: [ false, false, 11 ]},
+    { syntax: '{{>exp1}}                    ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: false, isSingleID: false, result: [ 'PartialStatement', false, 11 ]},
+    { syntax: '{{!exp1}}                    ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: false, isSingleID: false, result: [ 'CommentStatement', false, 11 ]},
+    // it is fine to pass util test, as Handlebars parser will fails the second &exp2
+    { syntax: '{{exp1 &exp2}}               ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: 'exp1',isSingleID: false, result: [ false, true, 11 ]},
+    // we skip this pattern
+    { syntax: '{{}}                         ', type: handlebarsUtils.ESCAPE_EXPRESSION, rstr: false, isSingleID: false, result: [ false, false, 11 ]},
+];
+exports.escapeExpressionTestPatterns = escapeExpressionTestPatterns;
+
+var referenceExpressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{&expression}}          ', type: handlebarsUtils.REFERENCE_EXPRESSION, rstr: 'expression', result: [ 'MustacheStatement', true, 14 ]},
+    // it is fine to have space in the reference.
+    { syntax: '{{&   expression     }}  ', type: handlebarsUtils.REFERENCE_EXPRESSION, rstr: 'expression', result: [ 'MustacheStatement', true, 22 ]},
+    // it is fine to have whitespace control in the reference.
+    { syntax: '{{~&expression~}}        ', type: handlebarsUtils.REFERENCE_EXPRESSION, rstr: 'expression', result: [ 'MustacheStatement', true, 16 ]},
+    // it is fine to have space at the end of whitespace control in the reference.
+    { syntax: '{{~&expression    ~}}    ', type: handlebarsUtils.REFERENCE_EXPRESSION, rstr: 'expression', result: [ 'MustacheStatement', true, 20 ]},
+    // for non-greedy match
+    { syntax: '{{&expression}} {{&expression}}', type: handlebarsUtils.REFERENCE_EXPRESSION, rstr: 'expression', result: [ 'MustacheStatement', true, 14 ]},
+    // new line char test
+    { syntax: '{{&exp\rression}}     ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:'exp', result: [ 'MustacheStatement', true, 15 ]},
+    { syntax: '{{&exp\nression}}     ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:'exp', result: [ 'MustacheStatement', true, 15 ]},
+
+    // invalid syntax
+    // the cph test can pass as there is no isValidExpression to guard against
+    { syntax: '{{ &expression}}      ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:false, result: [ false, false, 15 ]},
+    { syntax: '{{ & expression}}     ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:false, result: [ false, false, 16 ]},
+    { syntax: '{{~ &expression}}     ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:false, result: [ false, false, 16 ]},
+    { syntax: '{{&expression}}}      ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:false, result: [ false, false, 14 ]},
+    // '~' must be next to '}}'
+    { syntax: '{{&expression  ~ }}   ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:false, result: [ false, false, 18 ]},
+    // with one brace less 
+    { syntax: '{{&expression}        ', type:handlebarsUtils.REFERENCE_EXPRESSION, rstr:false, result: [ false, false, false ]},
+];
+exports.referenceExpressionTestPatterns = referenceExpressionTestPatterns;
+
+var partialExpressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{>partial}}        ', type: handlebarsUtils.PARTIAL_EXPRESSION, rstr: 'partial', result: [ 'PartialStatement', true, 11 ]},
+    // it is fine to have space in the partial.
+    { syntax: '{{>   partial   }}  ', type: handlebarsUtils.PARTIAL_EXPRESSION, rstr: 'partial', result: [ 'PartialStatement', true, 17 ]},
+    // it is fine to have whitespace control in the partial.
+    { syntax: '{{~>partial~}}      ', type: handlebarsUtils.PARTIAL_EXPRESSION, rstr: 'partial', result: [ 'PartialStatement', true, 13 ]},
+    // it is fine to have space at the end of whitespace control in the partial.
+    { syntax: '{{~>partial    ~}}  ', type: handlebarsUtils.PARTIAL_EXPRESSION, rstr: 'partial', result: [ 'PartialStatement', true, 17 ]},
+    // for non-greedy match
+    { syntax: '{{>partial}} {{>partial}}', type: handlebarsUtils.PARTIAL_EXPRESSION, rstr: 'partial', result: [ 'PartialStatement', true, 11 ]},
+    // new line char test
+    { syntax: '{{>par\rtial}}     ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:'par', result: [ 'PartialStatement', true, 12 ]},
+    { syntax: '{{>par\ntial}}     ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:'par', result: [ 'PartialStatement', true, 12 ]},
+
+    // invalid syntax
+    // the cph test can pass as there is no isValidExpression to guard against
+    { syntax: '{{ >partial}}      ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:false, result: [ false, false, 12 ]},
+    { syntax: '{{ > partial}}     ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:false, result: [ false, false, 13 ]},
+    { syntax: '{{~ >partial}}     ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:false, result: [ false, false, 13 ]},
+    { syntax: '{{>partial}}}      ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:false, result: [ false, false, 11 ]},
+    // '~' must be next to '}}'
+    { syntax: '{{>partial  ~ }}   ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:false, result: [ false, false, 15 ]},
+    // with one brace less 
+    { syntax: '{{>partial}        ', type:handlebarsUtils.PARTIAL_EXPRESSION, rstr:false, result: [ false, false, false ]},
+];
+exports.partialExpressionTestPatterns = partialExpressionTestPatterns;
+
+var branchExpressionTestPatterns = [
+    // valid syntax (#)
+    { syntax: '{{#if}} xxx {{/if}}                   ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 18 ]},
+    // it is fine to have space in the branching expression.
+    { syntax: '{{#  if   }} xxx {{/  if   }}         ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 28 ]},
+    // it is fine to have whitespace control in the branching expression.
+    { syntax: '{{~#  if   ~}} xxx {{~/  if   ~}}     ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 32 ]},
+    { syntax: '{{#if yyy}} xxx {{/if}}               ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 22 ]},
+    // for non-greedy match
+    { syntax: '{{#if}} xxx {{/if}}{{#if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 18 ]},
+    // new line char test
+    { syntax: '{{#if\ryyy}} xxx {{/if}}              ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 22 ]},
+
+    // valid syntax (^)
+    { syntax: '{{^if}} xxx {{/if}}                   ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 18 ]},
+    // it is fine to have space in the branching expression.
+    { syntax: '{{^  if   }} xxx {{/  if   }}         ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 28 ]},
+    // it is fine to have whitespace control in the branching expression.
+    { syntax: '{{~^  if   ~}} xxx {{~/  if   ~}}     ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 32 ]},
+    { syntax: '{{^if yyy}} xxx {{/if}}               ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 22 ]},
+    // for non-greedy match
+    { syntax: '{{^if}} xxx {{/if}}{{^if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 18 ]},
+    // new line char test
+    { syntax: '{{^if\ryyy}} xxx {{/if}}              ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 22 ]},
+
+    // valid syntax with else
+    { syntax: '{{#if}} xxx {{else}} yyy {{/if}}      ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 31 ]},
+    { syntax: '{{#if}} xxx {{  else  }} yyy {{/if}}  ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 35 ]},
+    { syntax: '{{#if}} xxx {{~  else  ~}} yyy {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 37 ]},
+    { syntax: '{{#if}} xxx {{^}} yyy {{/if}}         ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 28 ]},
+    { syntax: '{{#if}} xxx {{~^~}} yyy {{/if}}       ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 30 ]},
+
+    // valid syntax with else if
+    { syntax: '{{#if}} xxx {{  else if }} yyy {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ 'BlockStatement', true, 37 ]},
+
+    // invalid syntax
+    { syntax: '{{  #if}} xxx {{/if}}  ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if} xxx {{/if}}     ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{~ #if}} xxx {{/if}}  ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    // the utils test can be true as it only parses the first expression, but it is invalid handlebarsUtils.BRANCH_END_EXPRESSION test.
+    { syntax: '{{#if}} xxx {{  /if}}  ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ false, true, false ]},
+    { syntax: '{{#if}} xxx {{/if}     ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ false, true, false ]},
+    { syntax: '{{#if}} xxx {{~ /if}}  ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ false, true, false ]},
+    // the utils test can be true as it only parses the first expression, but it is invalid handlebarsUtils.ELSE_EXPRESSION test.
+    // the cph test can be true as the else expression is regarded as string, TODO: any issue?
+    { syntax: '{{#if}} xxx {{ ^ }} yyy {{/if}}   ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ false, true, false ]},
+    { syntax: '{{#if}} xxx {{~ ^ ~}} yyy {{/if}} ', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:'if', result: [ false, true, false ]},
+
+    // throw exception, {{#if}} does not support special character and white space control.
+    // reference http://handlebarsjs.com/expressions.html
+    { syntax: '{{#!if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#"if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{##if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#%if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#&if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: "{{#'if}} xxx {{/if}}", type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#(if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#)if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#*if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#+if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#,if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#.if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#/if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#;if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#>if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#=if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#<if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]}, 
+    { syntax: '{{#@if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#[if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#^if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#]if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#{if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#}if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#~if}} xxx {{/if}}', type:handlebarsUtils.BRANCH_EXPRESSION, rstr:false, result: [ false, false, false ]},
+];
+exports.branchExpressionTestPatterns = branchExpressionTestPatterns;
+
+/* just test for the util test only */
+var branchEndExpressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{/if}}          ', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:'if', result: [ '', true, '' ]},
+    // it is fine to have space in the branching expression.
+    { syntax: '{{/  if  }}      ', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:'if', result: [ '', true, '' ]},
+    // it is fine to have whitespace control in the branching expression.
+    { syntax: '{{~/  if  ~}}    ', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:'if', result: [ '', true, '' ]},
+
+    // throw exception, {{/if}} does not support special character and white space control.
+    // reference http://handlebarsjs.com/expressions.html
+    { syntax: '{{#if}} xxx {{/!if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/"if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/#if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/%if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/&if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: "{{#if}} xxx {{/'if}}", type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/(if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/)if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/*if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/+if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/,if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/.if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{//if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/;if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/>if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/=if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/<if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/@if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/[if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/^if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/]if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/{if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/}if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+    { syntax: '{{#if}} xxx {{/~if}}', type:handlebarsUtils.BRANCH_END_EXPRESSION, rstr:false, result: [ false, false, false ]},
+];
+exports.branchEndExpressionTestPatterns = branchEndExpressionTestPatterns;
+
+/* just test for the util test only */
+var elseExpressionTestPatterns = [
+    // valid syntax
+    { syntax: '{{else}}        ', type:handlebarsUtils.ELSE_EXPRESSION, rstr: undefined, result: [ '', true, '' ]},
+    // it is fine to have space in the {{else if}}.
+    { syntax: '{{  else if }}  ', type:handlebarsUtils.ELSE_EXPRESSION, rstr: undefined, result: [ '', true, '' ]},
+    // it is fine to have space in the {{else}}.
+    { syntax: '{{  else  }}    ', type:handlebarsUtils.ELSE_EXPRESSION, rstr: undefined, result: [ '', true, '' ]},
+    // it is fine to have whitespace control in the {{else}}
+    { syntax: '{{~  else  ~}}  ', type:handlebarsUtils.ELSE_EXPRESSION, rstr: undefined, result: [ '', true, '' ]},
+    { syntax: '{{^}}           ', type:handlebarsUtils.ELSE_EXPRESSION, rstr: undefined, result: [ '', true, '' ]},
+    { syntax: '{{~^~}}         ', type:handlebarsUtils.ELSE_EXPRESSION, rstr: undefined, result: [ '', true, '' ]},
+
+    // invalid syntax
+    { syntax: '{{ ^ }}         ', type:handlebarsUtils.ELSE_EXPRESSION, rstr:false, result: [ '', false, false ]},
+    { syntax: '{{~ ^ ~}}       ', type:handlebarsUtils.ELSE_EXPRESSION, rstr:false, result: [ '', false, false ]},
+];
+exports.elseExpressionTestPatterns = elseExpressionTestPatterns;
+
+var commentExpressionTestPatterns = [
+    // valid syntax (short form)
+    { syntax: '{{!comment}}     ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 11 ], },
+    // last '}}' does not count as comment
+    { syntax: '{{!comment}}}}   ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 11 ], },
+    // '--' does not count as comment (short form can end with long form)
+    { syntax: '{{!comment--}}   ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 13 ], },
+    // '--' count as comment
+    { syntax: '{{!comment--  }} ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 15 ], },
+    // '--' count as comment and '~' does not count as comment
+    { syntax: '{{!comment-- ~}} ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 15 ], },
+    // '--' and '~' count as comment 
+    { syntax: '{{!comment-- ~ }}', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 16 ], },
+    // '~' does not count as comment 
+    { syntax: '{{~!comment}}    ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: undefined, result: [ 'CommentStatement', true, 12 ], },
+
+    // invalid syntax (short form)
+    // the cph test can be true as it consumes till '}}'. TODO: it may affect the escape expression parsing.
+    { syntax: '{{~ !comment}}   ', type:handlebarsUtils.COMMENT_EXPRESSION_SHORT_FORM, rstr: false, result: [ false, false, 13 ], },
+
+    // valid syntax (long form)
+    { syntax: '{{!--comment--}}    ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ 'CommentStatement', true, 15 ], },
+    // last '}}' does not count as comment
+    { syntax: '{{!--comment--}}}}  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ 'CommentStatement', true, 15 ], },
+    // it is regard as short form and end with long form, the first '-' and last '--' does not count as comment
+    { syntax: '{{!- -comment--}}   ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: false,     result: [ 'CommentStatement', false, 16 ], },
+    // it is regard as short form and end with long form, the last '--' does not count as comment
+    { syntax: '{{!  --comment--}}  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: false,     result: [ 'CommentStatement', false, 17 ], },
+    // '~' does not count as comment
+    { syntax: '{{~!--comment--}}   ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ 'CommentStatement', true, 16 ], },
+    // '~' and '--' does not count as comment
+    { syntax: '{{~!--comment--~}}  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ 'CommentStatement', true, 17 ], },
+    // '~' and '--' does not count as comment
+    { syntax: '{{!--comment --~}}  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ 'CommentStatement', true, 17 ], },
+
+    // invalid syntax (long form)
+    // the cph test can be true as it consumes till '--}}'. TODO: it may affect the escape expression parsing.
+    { syntax: '{{~ !--comment--}}  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: false, result: [ false, false, 17 ], },
+    { syntax: '{{ !--comment--}}   ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: false, result: [ false, false, 16 ], },
+    // long form cannot find the end '--}}'
+    { syntax: '{{!--comment}}      ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ false, true, false ], },
+    { syntax: '{{!--comment - - }} ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ false, true, false ], },
+    { syntax: '{{!--comment -- }}  ', type:handlebarsUtils.COMMENT_EXPRESSION_LONG_FORM, rstr: undefined, result: [ false, true, false ], },
+];
+exports.commentExpressionTestPatterns = commentExpressionTestPatterns;
 
 })();


### PR DESCRIPTION
- consolidate and remove unnecessary code
- add the tests/utils.js for all test patterns for parsing
- add the config object (with printCharEnable and strictMode)
- support the {{&expression}}